### PR TITLE
Update ci/cd go version to 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.22'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
I noticed the testing ci/cd pipeline is using go version **1.21**.
Both go.mod and go.work target go version **1.22**.
I just thought the project should be tested using the same version as it targets.

Feel free to close the PR if you think this is incorrect.



Cheers! 🚀