### PR TITLE
fix: Set body height to 100% of the viewport height

### DIFF
--- a/openapi_handler.go
+++ b/openapi_handler.go
@@ -17,7 +17,7 @@ func defaultOpenAPIHandler(specURL string) http.Handler {
 	<script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
 	<link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css" />
 </head>
-<body>
+<body style="height: 100vh;">
 	<elements-api
 		apiDescriptionUrl="` + specURL + `"
 		layout="responsive"


### PR DESCRIPTION
Thank you for the fantastic work your team has done. When I use fuego for a demo, I noticed that the documentation does not display correctly on my extended screen, as follows:
![image](https://github.com/danielgtaylor/huma/assets/5282978/cf060a9c-2067-4811-8cdd-eb562225b285)

I found a solution on the Stoplight documentation website that suggests resolving the issue by adding a style configuration to the body.
```html
<body style="height: 100vh;">
    <stoplight-api />
</body>
```
[Stoplight Layout](https://docs.stoplight.io/docs/elements/d536b917a4e1d-layout)

Hope this issue can be fixed!