### PR TITLE
Hide from Openapi Spec

### DIFF
--- a/documentation/docs/guides/openapi.md
+++ b/documentation/docs/guides/openapi.md
@@ -124,3 +124,37 @@ Please note that if you embed swagger ui in your build it will increase its size
 | ------------- | ------------------ | -------------- | -------- |
 | Works offline | No ❌              | Yes ✅         | -        |
 | Binary Size   | Smaller            | Larger (+10Mb) | Smaller  |
+
+## Hide From Openapi Spec
+
+Certain routes such as web routes you may not want to be part of the openapi spec.
+
+You can prevent them from being added with the server.Hide().
+
+```go
+package main
+
+import (
+	"github.com/go-fuego/fuego"
+)
+
+func main() {
+	s := fuego.NewServer()
+
+	// Create a group of routes to be hidden
+	web := s.Group(s, "/")
+	web.Hide()
+
+	fuego.Get(web, "/", func(c fuego.ContextNoBody) (string, error) {
+		return "Hello, World!", nil
+	})
+
+	// These routes will still be added to the spec
+	api := s.Group(s, "/api")
+	fuego.Get(api, "/hello", func(c fuego.ContextNoBody) (string, error) {
+		return "Hello, World!", nil
+	})
+
+	s.Run()
+}
+```

--- a/mux.go
+++ b/mux.go
@@ -91,6 +91,12 @@ func register[T any, B any](s *Server, method string, path string, controller ht
 	allMiddlewares := append(middlewares, s.middlewares...)
 	s.Mux.Handle(fullPath, withMiddlewares(controller, allMiddlewares...))
 
+	if s.DisableOpenapi {
+		return Route[T, B]{
+			operation: &openapi3.Operation{},
+		}
+	}
+
 	operation, err := RegisterOpenAPIOperation[T, B](s, method, s.basePath+path)
 	if err != nil {
 		slog.Warn("error documenting openapi operation", "error", err)

--- a/mux_test.go
+++ b/mux_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -243,6 +244,19 @@ func TestDeleteStd(t *testing.T) {
 
 	require.Equal(t, w.Code, http.StatusOK)
 	require.Equal(t, w.Body.String(), "test successful")
+}
+
+func TestHideOpenapiRoutes(t *testing.T) {
+	s := NewServer()
+	s.Hide()
+	Get(s, "/test", func(ctx *ContextNoBody) (string, error) {
+		return "test", nil
+	})
+
+	require.Equal(t, s.DisableOpenapi, true)
+	require.Equal(t, s.OpenApiSpec.Components.Schemas, openapi3.Schemas{})
+	require.Equal(t, s.OpenApiSpec.Components.Responses, openapi3.ResponseBodies{})
+	require.Equal(t, s.OpenApiSpec.Components.RequestBodies, openapi3.RequestBodies{}, "test successful")
 }
 
 func BenchmarkRequest(b *testing.B) {

--- a/openapi.go
+++ b/openapi.go
@@ -35,6 +35,12 @@ func NewOpenApiSpec() openapi3.T {
 	return spec
 }
 
+// Prevents the routes in this server or group from being included in the OpenAPI spec.
+func (s *Server) Hide() *Server {
+	s.DisableOpenapi = true
+	return s
+}
+
 func (s *Server) generateOpenAPI() openapi3.T {
 	// Validate
 	err := s.OpenApiSpec.Validate(context.Background())

--- a/options.go
+++ b/options.go
@@ -50,6 +50,7 @@ type Server struct {
 	template *template.Template // TODO: use preparsed templates
 
 	DisallowUnknownFields bool // If true, the server will return an error if the request body contains unknown fields. Useful for quick debugging in development.
+	DisableOpenapi        bool // If true, the the routes within the server will not generate an openapi spec.
 	maxBodySize           int64
 	Serialize             func(w http.ResponseWriter, ans any)   // Used to serialize the response. Defaults to [SendJSON].
 	SerializeError        func(w http.ResponseWriter, err error) // Used to serialize the error response. Defaults to [SendJSONError].


### PR DESCRIPTION
Added being able to hide routes from the server, by using server.Hide()

Implements server.Hide() from #60 