### PR TITLE
add WithAddr option, adjusted WithPort func to only handle port

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ type MyResponse struct {
 
 func main() {
 	s := fuego.NewServer(
-		fuego.WithPort("8088"),
+		fuego.WithAddr("localhost:8088"),
 	)
 
 	fuego.Use(s, cors.Default().Handler)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ type MyResponse struct {
 
 func main() {
 	s := fuego.NewServer(
-		fuego.WithPort(":8088"),
+		fuego.WithPort("8088"),
 	)
 
 	fuego.Use(s, cors.Default().Handler)

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -22,7 +22,7 @@ type MyResponse struct {
 
 func main() {
 	s := fuego.NewServer(
-		fuego.WithPort(":8088"),
+		fuego.WithAddr("localhost:8088"),
 	)
 
 	fuego.Use(s, cors.Default().Handler)

--- a/openapi.go
+++ b/openapi.go
@@ -94,8 +94,8 @@ func generateSwagger(s *Server, jsonSpec []byte) {
 
 	Handle(s, s.OpenapiConfig.SwaggerUrl+"/", s.UIHandler(s.OpenapiConfig.JsonUrl))
 
-	slog.Info(fmt.Sprintf("JSON spec: http://localhost%s%s", s.Server.Addr, s.OpenapiConfig.JsonUrl))
-	slog.Info(fmt.Sprintf("OpenAPI UI: http://localhost%s%s/index.html", s.Server.Addr, s.OpenapiConfig.SwaggerUrl))
+	slog.Info(fmt.Sprintf("JSON spec: http://%s%s", s.Server.Addr, s.OpenapiConfig.JsonUrl))
+	slog.Info(fmt.Sprintf("OpenAPI UI: http://%s%s/index.html", s.Server.Addr, s.OpenapiConfig.SwaggerUrl))
 }
 
 func validateJsonSpecLocalPath(jsonSpecLocalPath string) bool {

--- a/options.go
+++ b/options.go
@@ -232,7 +232,7 @@ func WithPort(port string) func(*Server) {
 }
 
 // WithAddr optionally specifies the TCP address for the server to listen on, in the form "host:port".
-// If not used port 9999 is used.
+// If not specified addr ':9999' will be used.
 func WithAddr(addr string) func(*Server) {
 	return func(c *Server) { c.Server.Addr = addr }
 }

--- a/options.go
+++ b/options.go
@@ -1,12 +1,14 @@
 package fuego
 
 import (
+	"fmt"
 	"html/template"
 	"io"
 	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -93,7 +95,7 @@ func NewServer(options ...func(*Server)) *Server {
 	}
 
 	defaultOptions := [...]func(*Server){
-		WithPort(":9999"),
+		WithPort("9999"),
 		WithDisallowUnknownFields(true),
 		WithSerializer(SendJSON),
 		WithErrorSerializer(SendJSONError),
@@ -217,7 +219,20 @@ func WithDisallowUnknownFields(b bool) func(*Server) {
 
 // WithPort sets the port of the server. For example, ":8080".
 func WithPort(port string) func(*Server) {
-	return func(c *Server) { c.Server.Addr = port }
+	var addr string
+	if strings.HasPrefix(port, ":") {
+		addr = port
+	} else {
+		addr = fmt.Sprintf(":%s", port)
+	}
+
+	return func(c *Server) { c.Server.Addr = addr }
+}
+
+// WithAddr optionally specifies the TCP address for the server to listen on, in the form "host:port".
+// If not used port 9999 is used.
+func WithAddr(addr string) func(*Server) {
+	return func(c *Server) { c.Server.Addr = addr }
 }
 
 func WithXML() func(*Server) {

--- a/options.go
+++ b/options.go
@@ -218,6 +218,8 @@ func WithDisallowUnknownFields(b bool) func(*Server) {
 }
 
 // WithPort sets the port of the server. For example, ":8080".
+//
+// Deprecated: Use WithAddr instead as that allows to set the host and the port.
 func WithPort(port string) func(*Server) {
 	var addr string
 	if strings.HasPrefix(port, ":") {

--- a/options.go
+++ b/options.go
@@ -71,7 +71,7 @@ type Server struct {
 // For example:
 //
 //	app := fuego.NewServer(
-//		fuego.WithPort(":8080"),
+//		fuego.WithAddr(":8080"),
 //		fuego.WithoutLogger(),
 //	)
 //
@@ -95,7 +95,7 @@ func NewServer(options ...func(*Server)) *Server {
 	}
 
 	defaultOptions := [...]func(*Server){
-		WithPort("9999"),
+		WithAddr(":9999"),
 		WithDisallowUnknownFields(true),
 		WithSerializer(SendJSON),
 		WithErrorSerializer(SendJSONError),
@@ -217,7 +217,7 @@ func WithDisallowUnknownFields(b bool) func(*Server) {
 	return func(c *Server) { c.DisallowUnknownFields = b }
 }
 
-// WithPort sets the port of the server. For example, ":8080".
+// WithPort sets the port of the server. For example, "8080".
 //
 // Deprecated: Use WithAddr instead as that allows to set the host and the port.
 func WithPort(port string) func(*Server) {

--- a/options_test.go
+++ b/options_test.go
@@ -222,3 +222,78 @@ func TestWithValidator(t *testing.T) {
 		)
 	}
 }
+
+func TestWithAddr(t *testing.T) {
+	tests := []struct {
+		name         string
+		addr         string
+		expectedAddr string
+	}{
+		{
+			name:         "with custom addr, that addr is used",
+			addr:         "localhost:8888",
+			expectedAddr: "localhost:8888",
+		},
+		{
+			name:         "no addr provided, default is used (9999)",
+			addr:         "",
+			expectedAddr: ":9999",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				var opts []func(*Server)
+
+				if tt.addr != "" {
+					opts = append(opts, WithAddr(tt.addr))
+				}
+
+				s := NewServer(
+					opts...,
+				)
+				require.Equal(t, tt.expectedAddr, s.Server.Addr)
+			},
+		)
+	}
+}
+
+func TestWithPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		port         string
+		expectedAddr string
+	}{
+		{
+			name:         "port provided with :",
+			port:         ":8888",
+			expectedAddr: ":8888",
+		},
+		{
+			name:         "port provided without :",
+			port:         "8888",
+			expectedAddr: ":8888",
+		},
+		{
+			name:         "no port provided",
+			port:         "",
+			expectedAddr: ":9999",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				var opts []func(*Server)
+
+				if tt.port != "" {
+					opts = append(opts, WithPort(tt.port))
+				}
+
+				s := NewServer(
+					opts...,
+				)
+				require.Equal(t, tt.expectedAddr, s.Server.Addr)
+			},
+		)
+	}
+}

--- a/serve.go
+++ b/serve.go
@@ -16,7 +16,7 @@ func (s *Server) Run() error {
 	go s.generateOpenAPI()
 	elapsed := time.Since(s.startTime)
 	slog.Debug("Server started in "+elapsed.String(), "info", "time between since server creation (fuego.NewServer) and server startup (fuego.Run). Depending on your implementation, there might be things that do not depend on fuego slowing start time")
-	slog.Info("Server running ✅ on http://localhost"+s.Server.Addr, "started in", elapsed.String())
+	slog.Info("Server running ✅ on http://"+s.Server.Addr, "started in", elapsed.String())
 
 	s.Server.Handler = s.Mux
 


### PR DESCRIPTION
# Description

This PR adds the option `WithAddr` to the server, which lets you specify the full "host:port" for the server to be run at. The `WithPort` func currently allows you to do this, but it's not obvious that you can. I believe it's better to be explicit about this, hence the addition.

With this change I've also deprecated `WithPort` but kept it for backwards compatibility. Up to you how you want to do it. One case that is not covered is if `WithPort` has been used to provide the complete addr: `WithAddr(localhost:8080)`.

I've also updated the log rows and the example in the README.

What do you think?