### PR TITLE
feat: support decoding x-yaml content-type in ContextWithBody

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -363,6 +363,8 @@ func body[B any](c ContextNoBody) (B, error) {
 		err = errReadingString
 	case "application/x-www-form-urlencoded", "multipart/form-data":
 		body, err = readURLEncoded[B](c.Req, c.readOptions)
+	case "application/x-yaml":
+		return readYAML[B](c.Req.Context(), c.Req.Body, c.readOptions)
 	case "application/json":
 		fallthrough
 	default:


### PR DESCRIPTION
The following adds the ability to submit yaml as a content type to be decoded ContextWithBody. I'm not quite sure if I did this probably as this comment [is throwing me off but it could just be a mistake?](https://github.com/go-fuego/fuego/commit/3bb79ad6313b8b81a4d9c96ad07954648ebf978f#diff-c4dd82978a1a49bcd620aff72208bbd8114f09341d701e188c247ce3e3511117R104)

Anyhow let me know your thoughts. I'm open to changing things up if this doesn't suffice. If there isn't any interest let me know as well. 

The pattern I chose here seems like it could be extended to XML easily as well. 