### PR TITLE
Fixes error Content-Type

### DIFF
--- a/serialization.go
+++ b/serialization.go
@@ -92,16 +92,18 @@ func SendJSON(w http.ResponseWriter, ans any) {
 // If the error implements ErrorWithStatus, the status code will be set.
 func SendJSONError(w http.ResponseWriter, err error) {
 	status := http.StatusInternalServerError
-	errorStatus := HTTPError{
-		Err: err,
-	}
+	var errorStatus ErrorWithStatus
 	if errors.As(err, &errorStatus) {
 		status = errorStatus.StatusCode()
 	}
 
 	w.WriteHeader(status)
-	w.Header().Set("Content-Type", "application/problem+json")
-	SendJSON(w, errorStatus)
+	SendJSON(w, err)
+
+	var httpError HTTPError
+	if errors.As(err, &httpError) {
+		w.Header().Set("Content-Type", "application/problem+json")
+	}
 }
 
 // SendXML sends a XML response.

--- a/tests_test.go
+++ b/tests_test.go
@@ -1,0 +1,46 @@
+package fuego
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Contains random tests reported on the issues.
+
+func TestContentType(t *testing.T) {
+	server := NewServer()
+
+	t.Run("Sends application/problem+json when return type is HTTPError", func(t *testing.T) {
+		GetStd(server, "/json-problems", func(w http.ResponseWriter, r *http.Request) {
+			SendJSONError(w, UnauthorizedError{
+				Title: "Unauthorized",
+			})
+		})
+
+		req := httptest.NewRequest("GET", "/json-problems", nil)
+		w := httptest.NewRecorder()
+		server.Mux.ServeHTTP(w, req)
+
+		require.Equal(t, "application/problem+json", w.Header().Get("Content-Type"))
+		require.Equal(t, 401, w.Code)
+		require.Contains(t, w.Body.String(), "Unauthorized")
+	})
+
+	t.Run("Sends application/json when return type is not HTTPError", func(t *testing.T) {
+		GetStd(server, "/json", func(w http.ResponseWriter, r *http.Request) {
+			SendJSONError(w, errors.New("error"))
+		})
+
+		req := httptest.NewRequest("GET", "/json", nil)
+		w := httptest.NewRecorder()
+		server.Mux.ServeHTTP(w, req)
+
+		require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+		require.Equal(t, 500, w.Code)
+		require.Equal(t, "{}\n", w.Body.String())
+	})
+}


### PR DESCRIPTION
When returning `UnauthorizedError`, returns the `application/problem+json` Content-Type header.

When returning any `error`, returns the `application/json` Content-Type header.

Fixes #87 