### PR TITLE
fix: fuego controller command

### DIFF
--- a/cmd/fuego/commands/controller.go
+++ b/cmd/fuego/commands/controller.go
@@ -65,10 +65,12 @@ func createController(controllerName, outputFile string) (string, error) {
 
 	controllerPath := outputFile
 	if controllerPath == "" {
-		controllerPath = fmt.Sprintf("%s%s.go", outputFile, controllerName)
+		controllerPath = fmt.Sprintf("%s.go", controllerName)
+	} else if !strings.HasSuffix(controllerPath, ".go") {
+		controllerPath = fmt.Sprintf("%s.go", controllerPath)
 	}
 
-	err = os.WriteFile(controllerPath, []byte(newContent), 0o644)
+	err = os.WriteFile(fmt.Sprintf("controllers/%s", controllerPath), []byte(newContent), 0o644)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Hello, I just found out about fuego.
While following the tutorial, I discovered that the operation of the `fuego controller` command was strange.

1. Run fuego controller books
2. Create controllers folder
3. Create books.go in the root, not the controllers folder.

This resulted in me having to manually move the files into the controllers folder.

- [ ] Modify main.go code in https://go-fuego.github.io/fuego/docs/tutorials/crud 

This has been corrected.

fyi: I don't know why the --output option exists. Please let me know if you think it is unnecessary

thanks :)