### PR TITLE
Fuego Context is std lib context

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -124,6 +124,9 @@ type ContextNoBody struct {
 	readOptions readOptions
 }
 
+var _ ctx[any] = ContextNoBody{}        // Check that ContextNoBody implements Ctx.
+var _ context.Context = ContextNoBody{} // Check that ContextNoBody implements context.Context.
+
 func (c ContextNoBody) Body() (any, error) {
 	slog.Warn("this method should not be called. It probably happened because you passed the context to another controller.")
 	return body[map[string]any](c)
@@ -163,6 +166,27 @@ func (c ContextNoBody) Redirect(code int, url string) (any, error) {
 	return nil, nil
 }
 
+// ContextNoBody implements the context interface via [net/http.Request.Context]
+func (c ContextNoBody) Deadline() (deadline time.Time, ok bool) {
+	return c.Req.Context().Deadline()
+}
+
+// ContextNoBody implements the context interface via [net/http.Request.Context]
+func (c ContextNoBody) Done() <-chan struct{} {
+	return c.Req.Context().Done()
+}
+
+// ContextNoBody implements the context interface via [net/http.Request.Context]
+func (c ContextNoBody) Err() error {
+	return c.Req.Context().Err()
+}
+
+// ContextNoBody implements the context interface via [net/http.Request.Context]
+func (c ContextNoBody) Value(key any) any {
+	return c.Req.Context().Value(key)
+}
+
+// ContextNoBody implements the context interface via [net/http.Request.Context]
 func (c ContextNoBody) Context() context.Context {
 	return c.Req.Context()
 }

--- a/examples/full-app-gourmet/views/admin.ingredient.go
+++ b/examples/full-app-gourmet/views/admin.ingredient.go
@@ -22,7 +22,7 @@ func (rs Ressource) adminOneIngredient(c *fuego.ContextWithBody[store.UpdateIngr
 
 		updateIngredientArgs.ID = c.PathParam("id")
 
-		_, err = rs.IngredientsQueries.UpdateIngredient(c.Context(), updateIngredientArgs)
+		_, err = rs.IngredientsQueries.UpdateIngredient(c, updateIngredientArgs)
 		if err != nil {
 			return nil, err
 		}
@@ -30,7 +30,7 @@ func (rs Ressource) adminOneIngredient(c *fuego.ContextWithBody[store.UpdateIngr
 		c.Response().Header().Set("HX-Trigger", "entity-updated")
 	}
 
-	ingredient, err := rs.IngredientsQueries.GetIngredient(c.Context(), id)
+	ingredient, err := rs.IngredientsQueries.GetIngredient(c, id)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (rs Ressource) adminCreateIngredient(c *fuego.ContextWithBody[store.CreateI
 		return nil, err
 	}
 
-	_, err = rs.IngredientsQueries.CreateIngredient(c.Context(), createIngredientArgs)
+	_, err = rs.IngredientsQueries.CreateIngredient(c, createIngredientArgs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fuego ContextXxx are valid [context.Context](https://pkg.go.dev/context#Context). It is of course based on [the standard library](https://pkg.go.dev/net/http#Request.Context)