### PR TITLE
feat: add option to pretty print json doc output

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -59,7 +59,7 @@ func (s *Server) OutputOpenAPISpec() openapi3.T {
 	}
 
 	// Marshal spec to JSON
-	jsonSpec, err := json.Marshal(s.OpenApiSpec)
+	jsonSpec, err := s.marshalSpec()
 	if err != nil {
 		slog.Error("Error marshalling spec to JSON", "error", err)
 	}
@@ -76,6 +76,13 @@ func (s *Server) OutputOpenAPISpec() openapi3.T {
 	}
 
 	return s.OpenApiSpec
+}
+
+func (s *Server) marshalSpec() ([]byte, error) {
+	if s.OpenAPIConfig.PrettyFormatJson {
+		return json.MarshalIndent(s.OpenApiSpec, "", "	")
+	}
+	return json.Marshal(s.OpenApiSpec)
 }
 
 func saveOpenAPIToFile(jsonSpecLocalPath string, jsonSpec []byte) error {

--- a/options.go
+++ b/options.go
@@ -23,6 +23,7 @@ type OpenAPIConfig struct {
 	UIHandler        func(specURL string) http.Handler // Handler to serve the openapi ui from spec url
 	JsonUrl          string                            // URL to serve the openapi json spec
 	JsonFilePath     string                            // Local path to save the openapi json spec
+	PrettyFormatJson bool                              // Pretty prints the open api spec with proper json indentation
 }
 
 var defaultOpenAPIConfig = OpenAPIConfig{
@@ -288,13 +289,9 @@ func WithOpenAPIConfig(openapiConfig OpenAPIConfig) func(*Server) {
 			s.OpenAPIConfig.UIHandler = openapiConfig.UIHandler
 		}
 
-		if openapiConfig.DisableSwagger {
-			s.OpenAPIConfig.DisableSwagger = true
-		}
-
-		if openapiConfig.DisableLocalSave {
-			s.OpenAPIConfig.DisableLocalSave = true
-		}
+		s.OpenAPIConfig.DisableSwagger = openapiConfig.DisableSwagger
+		s.OpenAPIConfig.DisableLocalSave = openapiConfig.DisableLocalSave
+		s.OpenAPIConfig.PrettyFormatJson = openapiConfig.PrettyFormatJson
 
 		if !validateJsonSpecLocalPath(s.OpenAPIConfig.JsonFilePath) {
 			slog.Error("Error writing json spec. Value of 'jsonSpecLocalPath' option is not valid", "file", s.OpenAPIConfig.JsonFilePath)

--- a/options_test.go
+++ b/options_test.go
@@ -75,6 +75,7 @@ func TestWithOpenAPIConfig(t *testing.T) {
 		require.Equal(t, "/swagger", s.OpenAPIConfig.SwaggerUrl)
 		require.Equal(t, "/swagger/openapi.json", s.OpenAPIConfig.JsonUrl)
 		require.Equal(t, "doc/openapi.json", s.OpenAPIConfig.JsonFilePath)
+		require.False(t, s.OpenAPIConfig.PrettyFormatJson)
 	})
 
 	t.Run("with custom values", func(t *testing.T) {
@@ -85,6 +86,7 @@ func TestWithOpenAPIConfig(t *testing.T) {
 				JsonFilePath:     "openapi.json",
 				DisableSwagger:   true,
 				DisableLocalSave: true,
+				PrettyFormatJson: true,
 			}),
 		)
 
@@ -93,6 +95,7 @@ func TestWithOpenAPIConfig(t *testing.T) {
 		require.Equal(t, "openapi.json", s.OpenAPIConfig.JsonFilePath)
 		require.True(t, s.OpenAPIConfig.DisableSwagger)
 		require.True(t, s.OpenAPIConfig.DisableLocalSave)
+		require.True(t, s.OpenAPIConfig.PrettyFormatJson)
 	})
 
 	t.Run("with invalid local path values", func(t *testing.T) {


### PR DESCRIPTION
Provide the ability to pretty print to the .json file

Bit of a vanity thing, but I have some colleagues asking for it. What does make this nice is that it provides the ability to pretty print in CI and we can place the file into a npm package (that's generated from the spec) to be consumed by downstream API users. It also makes diffs useful source control managers.  