### PR TITLE
feat: add ability to disable startup message print

### DIFF
--- a/options.go
+++ b/options.go
@@ -53,8 +53,9 @@ type Server struct {
 
 	middlewares []func(http.Handler) http.Handler
 
-	disableAutoGroupTags bool
-	groupTag             string
+	disableStartupMessage bool
+	disableAutoGroupTags  bool
+	groupTag              string
 
 	basePath string
 
@@ -281,6 +282,11 @@ func WithErrorSerializer(serializer func(w http.ResponseWriter, err error)) func
 
 func WithErrorHandler(errorHandler func(err error) error) func(*Server) {
 	return func(c *Server) { c.ErrorHandler = errorHandler }
+}
+
+// WithoutStartupMessage disables the startup message
+func WithoutStartupMessage() func(*Server) {
+	return func(c *Server) { c.disableStartupMessage = true }
 }
 
 // WithoutLogger disables the default logger.

--- a/options_test.go
+++ b/options_test.go
@@ -275,6 +275,14 @@ func TestWithPort(t *testing.T) {
 	})
 }
 
+func TestWithoutStartupMessage(t *testing.T) {
+	s := NewServer(
+		WithoutStartupMessage(),
+	)
+
+	require.True(t, s.disableStartupMessage)
+}
+
 func TestWithoutAutoGroupTags(t *testing.T) {
 	s := NewServer(
 		WithoutAutoGroupTags(),

--- a/serve.go
+++ b/serve.go
@@ -15,17 +15,23 @@ import (
 // It also generates the OpenAPI spec and outputs it to a file, the UI, and a handler (if enabled).
 func (s *Server) Run() error {
 	go s.OutputOpenAPISpec()
-	elapsed := time.Since(s.startTime)
-	slog.Debug("Server started in "+elapsed.String(), "info", "time between since server creation (fuego.NewServer) and server startup (fuego.Run). Depending on your implementation, there might be things that do not depend on fuego slowing start time")
-	slog.Info("Server running ✅ on http://"+s.Server.Addr, "started in", elapsed.String())
+
+	if !s.disableStartupMessage {
+		s.printStartupMessage()
+	}
 
 	s.Server.Handler = s.Mux
-
 	if s.corsMiddleware != nil {
 		s.Server.Handler = s.corsMiddleware(s.Server.Handler)
 	}
 
 	return s.Server.ListenAndServe()
+}
+
+func (s *Server) printStartupMessage() {
+	elapsed := time.Since(s.startTime)
+	slog.Debug("Server started in "+elapsed.String(), "info", "time between since server creation (fuego.NewServer) and server startup (fuego.Run). Depending on your implementation, there might be things that do not depend on fuego slowing start time")
+	slog.Info("Server running ✅ on http://"+s.Server.Addr, "started in", elapsed.String())
 }
 
 // initializes any Context type with the base ContextNoBody context.


### PR DESCRIPTION
This is just noise in some cases. 

Should probably provide the ability to disable the openapi printing as well i.e

```
2024/04/16 17:01:30 INFO JSON spec: http://0.0.0.0:9999/swagger/openapi.json
2024/04/16 17:01:30 INFO OpenAPI UI: http://0.0.0.0:9999/swagger/index.html
2024/04/16 17:01:30 INFO JSON file: doc/openapi.json
```

The only thing I'm really debating about though is should we just always print the debug message here? Could be useful.