### PR TITLE
Feat/disable print openapi

### DIFF
--- a/openapi_test.go
+++ b/openapi_test.go
@@ -258,8 +258,9 @@ func TestValidateSwaggerUrl(t *testing.T) {
 }
 
 func TestLocalSave(t *testing.T) {
+	s := NewServer()
 	t.Run("with valid path", func(t *testing.T) {
-		err := saveOpenAPIToFile("/tmp/jsonSpec.json", []byte("test"))
+		err := s.saveOpenAPIToFile("/tmp/jsonSpec.json", []byte("test"))
 		require.NoError(t, err)
 
 		// cleanup
@@ -267,7 +268,7 @@ func TestLocalSave(t *testing.T) {
 	})
 
 	t.Run("with invalid path", func(t *testing.T) {
-		err := saveOpenAPIToFile("///jsonSpec.json", []byte("test"))
+		err := s.saveOpenAPIToFile("///jsonSpec.json", []byte("test"))
 		require.Error(t, err)
 	})
 }

--- a/options.go
+++ b/options.go
@@ -53,8 +53,9 @@ type Server struct {
 
 	middlewares []func(http.Handler) http.Handler
 
-	disableAutoGroupTags bool
-	groupTag             string
+	disableStartupMessage bool
+	disableAutoGroupTags  bool
+	groupTag              string
 
 	basePath string
 
@@ -281,6 +282,11 @@ func WithErrorSerializer(serializer func(w http.ResponseWriter, err error)) func
 
 func WithErrorHandler(errorHandler func(err error) error) func(*Server) {
 	return func(c *Server) { c.ErrorHandler = errorHandler }
+}
+
+// WithoutStartupMessage disables the startup message
+func WithoutStartupMessage() func(*Server) {
+	return func(c *Server) { c.disableStartupMessage = true }
 }
 
 // WithoutLogger disables the default logger.

--- a/options.go
+++ b/options.go
@@ -53,9 +53,9 @@ type Server struct {
 
 	middlewares []func(http.Handler) http.Handler
 
-	disableStartupMessage bool
-	disableAutoGroupTags  bool
-	groupTag              string
+	disableStartupMessages bool
+	disableAutoGroupTags   bool
+	groupTag               string
 
 	basePath string
 
@@ -285,8 +285,8 @@ func WithErrorHandler(errorHandler func(err error) error) func(*Server) {
 }
 
 // WithoutStartupMessage disables the startup message
-func WithoutStartupMessage() func(*Server) {
-	return func(c *Server) { c.disableStartupMessage = true }
+func WithoutStartupMessages() func(*Server) {
+	return func(c *Server) { c.disableStartupMessages = true }
 }
 
 // WithoutLogger disables the default logger.

--- a/options_test.go
+++ b/options_test.go
@@ -277,10 +277,10 @@ func TestWithPort(t *testing.T) {
 
 func TestWithoutStartupMessage(t *testing.T) {
 	s := NewServer(
-		WithoutStartupMessage(),
+		WithoutStartupMessages(),
 	)
 
-	require.True(t, s.disableStartupMessage)
+	require.True(t, s.disableStartupMessages)
 }
 
 func TestWithoutAutoGroupTags(t *testing.T) {

--- a/options_test.go
+++ b/options_test.go
@@ -275,6 +275,14 @@ func TestWithPort(t *testing.T) {
 	})
 }
 
+func TestWithoutStartupMessage(t *testing.T) {
+	s := NewServer(
+		WithoutStartupMessage(),
+	)
+
+	require.True(t, s.disableStartupMessage)
+}
+
 func TestWithoutAutoGroupTags(t *testing.T) {
 	s := NewServer(
 		WithoutAutoGroupTags(),

--- a/serve.go
+++ b/serve.go
@@ -16,9 +16,7 @@ import (
 func (s *Server) Run() error {
 	go s.OutputOpenAPISpec()
 
-	if !s.disableStartupMessage {
-		s.printStartupMessage()
-	}
+	s.printStartupMessage()
 
 	s.Server.Handler = s.Mux
 	if s.corsMiddleware != nil {
@@ -29,9 +27,11 @@ func (s *Server) Run() error {
 }
 
 func (s *Server) printStartupMessage() {
-	elapsed := time.Since(s.startTime)
-	slog.Debug("Server started in "+elapsed.String(), "info", "time between since server creation (fuego.NewServer) and server startup (fuego.Run). Depending on your implementation, there might be things that do not depend on fuego slowing start time")
-	slog.Info("Server running ✅ on http://"+s.Server.Addr, "started in", elapsed.String())
+	if !s.disableStartupMessages {
+		elapsed := time.Since(s.startTime)
+		slog.Debug("Server started in "+elapsed.String(), "info", "time between since server creation (fuego.NewServer) and server startup (fuego.Run). Depending on your implementation, there might be things that do not depend on fuego slowing start time")
+		slog.Info("Server running ✅ on http://"+s.Server.Addr, "started in", elapsed.String())
+	}
 }
 
 // initializes any Context type with the base ContextNoBody context.

--- a/serve.go
+++ b/serve.go
@@ -15,17 +15,23 @@ import (
 // It also generates the OpenAPI spec and outputs it to a file, the UI, and a handler (if enabled).
 func (s *Server) Run() error {
 	go s.OutputOpenAPISpec()
-	elapsed := time.Since(s.startTime)
-	slog.Debug("Server started in "+elapsed.String(), "info", "time between since server creation (fuego.NewServer) and server startup (fuego.Run). Depending on your implementation, there might be things that do not depend on fuego slowing start time")
-	slog.Info("Server running ✅ on http://"+s.Server.Addr, "started in", elapsed.String())
+
+	if !s.disableStartupMessage {
+		s.printStartupMessage()
+	}
 
 	s.Server.Handler = s.Mux
-
 	if s.corsMiddleware != nil {
 		s.Server.Handler = s.corsMiddleware(s.Server.Handler)
 	}
 
 	return s.Server.ListenAndServe()
+}
+
+func (s *Server) printStartupMessage() {
+	elapsed := time.Since(s.startTime)
+	slog.Debug("Server started in "+elapsed.String(), "info", "time between since server creation (fuego.NewServer) and server startup (fuego.Run). Depending on your implementation, there might be things that do not depend on fuego slowing start time")
+	slog.Info("Server running ✅ on http://"+s.Server.Addr, "started in", elapsed.String())
 }
 
 // initializes any Context type with the base ContextNoBody context.


### PR DESCRIPTION
Same ad #122 but extends the options to also disable the printing startup of openapi resources.