### PR TITLE
fix: differentiate between array types and standard structs

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -207,6 +207,8 @@ type schemaTag struct {
 
 func schemaTagFromType[V any](s *Server, v any) schemaTag {
 	if v == nil {
+		// ensure we add unknown-interface to our schemas
+		s.getOrCreateSchema("unknown-interface", struct{}{})
 		return schemaTag{
 			name: "unknown-interface",
 			SchemaRef: openapi3.SchemaRef{

--- a/openapi.go
+++ b/openapi.go
@@ -221,7 +221,7 @@ func schemaTagFromType[V any](s *Server, v any) (schemaTag, error) {
 		}, nil
 	}
 
-	return dive[V](s, reflect.TypeOf(v), schemaTag{}, 4)
+	return dive[V](s, reflect.TypeOf(v), schemaTag{}, 5)
 }
 
 func dive[V any](s *Server, t reflect.Type, tag schemaTag, maxDepth int) (schemaTag, error) {
@@ -244,6 +244,7 @@ func dive[V any](s *Server, t reflect.Type, tag schemaTag, maxDepth int) (schema
 			return schemaTag{}, err
 		}
 
+		tag.name = item.name
 		tag.Value = &openapi3.Schema{
 			Type:  "array",
 			Items: &item.SchemaRef,

--- a/openapi.go
+++ b/openapi.go
@@ -163,14 +163,11 @@ func RegisterOpenAPIOperation[T, B any](s *Server, method, path string) (*openap
 	// Request body
 	bodyTag := tagFromType(*new(B))
 	if (method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch) && bodyTag != "unknown-interface" && bodyTag != "string" {
-
-		bodySchema, err := generator.NewSchemaRefForValue(new(B), s.OpenApiSpec.Components.Schemas)
+		bodySchema, err := schemaRefFromType[B](s, *new(B))
 		if err != nil {
 			return operation, err
 		}
-
-		content := openapi3.NewContentWithSchema(bodySchema.Value, []string{"application/json"})
-		content["application/json"].Schema.Ref = "#/components/schemas/" + bodyTag
+		content := openapi3.NewContentWithSchemaRef(bodySchema, []string{"application/json"})
 		requestBody := openapi3.NewRequestBody().
 			WithRequired(true).
 			WithDescription("Request body for " + reflect.TypeOf(*new(B)).String()).
@@ -187,14 +184,12 @@ func RegisterOpenAPIOperation[T, B any](s *Server, method, path string) (*openap
 		}
 	}
 
-	tag := tagFromType(*new(T))
-	responseSchema, err := generator.NewSchemaRefForValue(new(T), s.OpenApiSpec.Components.Schemas)
+	responseSchema, err := schemaRefFromType[T](s, *new(T))
 	if err != nil {
 		return operation, err
 	}
 
-	content := openapi3.NewContentWithSchema(responseSchema.Value, []string{"application/json"})
-	content["application/json"].Schema.Ref = "#/components/schemas/" + tag
+	content := openapi3.NewContentWithSchemaRef(responseSchema, []string{"application/json"})
 	response := openapi3.NewResponse().
 		WithDescription("OK").
 		WithContent(content)
@@ -211,6 +206,53 @@ func RegisterOpenAPIOperation[T, B any](s *Server, method, path string) (*openap
 	s.OpenApiSpec.AddOperation(path, method, operation)
 
 	return operation, nil
+}
+
+func schemaRefFromType[V any](s *Server, v any) (*openapi3.SchemaRef, error) {
+	if v == nil {
+		return &openapi3.SchemaRef{
+			Ref: "#/components/schemas/unknown-interface",
+		}, nil
+	}
+
+	schemaRef, err := schemaDive[V](s, reflect.TypeOf(v), openapi3.SchemaRef{}, 4)
+	return &schemaRef, err
+}
+
+func schemaDive[V any](s *Server, t reflect.Type, schemaRef openapi3.SchemaRef, maxDepth int) (openapi3.SchemaRef, error) {
+	if maxDepth == 0 {
+		return openapi3.SchemaRef{
+			Ref: "#/components/schemas/default",
+		}, nil
+	}
+
+	switch t.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		return schemaDive[V](s, t.Elem(), schemaRef, maxDepth-1)
+	case reflect.Slice, reflect.Array:
+		item, err := schemaDive[V](s, t.Elem(), schemaRef, maxDepth-1)
+		if err != nil {
+			return schemaRef, err
+		}
+		schemaRef.Value = &openapi3.Schema{
+			Type:  "array",
+			Items: &item,
+		}
+		return schemaRef, nil
+	default:
+		componentRef, ok := s.OpenApiSpec.Components.Schemas[t.Name()]
+		if !ok {
+			var err error
+			componentRef, err = generator.NewSchemaRefForValue(new(V), s.OpenApiSpec.Components.Schemas)
+			if err != nil {
+				return openapi3.SchemaRef{}, err
+			}
+			s.OpenApiSpec.Components.Schemas[t.Name()] = componentRef
+		}
+		schemaRef.Value = componentRef.Value
+		schemaRef.Ref = "#/components/schemas/" + t.Name()
+		return schemaRef, nil
+	}
 }
 
 func tagFromType(v any) string {

--- a/openapi.go
+++ b/openapi.go
@@ -200,6 +200,7 @@ func RegisterOpenAPIOperation[T, B any](s *Server, method, path string) (*openap
 	return operation, nil
 }
 
+// schemaTag is a struct that holds the name of the struct and the associated openapi3.SchemaRef
 type schemaTag struct {
 	openapi3.SchemaRef
 	name string

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -30,13 +30,11 @@ type testCaseForTagType[V any] struct {
 	s           *Server
 
 	expectedTagValue string
-	expectedErr      error
 }
 
 func runTestCase[V any](tc testCaseForTagType[V]) func(t *testing.T) {
 	return func(t *testing.T) {
-		tag, err := schemaTagFromType[V](tc.s, tc.inputType)
-		require.Equal(t, tc.expectedErr, err, tc.description)
+		tag := schemaTagFromType[V](tc.s, tc.inputType)
 		assert.Equal(t, tc.expectedTagValue, tag.name, tc.description)
 	}
 }

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -67,6 +67,7 @@ func TestServer_generateOpenAPI(t *testing.T) {
 	require.NotNil(t, document.Paths.Find("/"))
 	require.Nil(t, document.Paths.Find("/unknown"))
 	require.NotNil(t, document.Paths.Find("/post"))
+	require.Equal(t, document.Paths.Find("/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type, "array")
 	require.NotNil(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200"))
 	require.NotNil(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200").Value.Content["application/json"])
 	require.Nil(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value.Properties["unknown"])

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -32,13 +32,6 @@ type testCaseForTagType[V any] struct {
 	expectedTagValue string
 }
 
-func runTestCase[V any](tc testCaseForTagType[V]) func(t *testing.T) {
-	return func(t *testing.T) {
-		tag := schemaTagFromType[V](tc.s, tc.inputType)
-		assert.Equal(t, tc.expectedTagValue, tag.name, tc.description)
-	}
-}
-
 func Test_tagFromType(t *testing.T) {
 	s := NewServer()
 	type DeeplyNested *[]MyStruct
@@ -139,7 +132,10 @@ func Test_tagFromType(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		t.Run(tc.name, runTestCase(tc))
+		t.Run(tc.name, func(t *testing.T) {
+			tag := schemaTagFromType(tc.s, tc.inputType)
+			assert.Equal(t, tc.expectedTagValue, tag.name, tc.description)
+		})
 	}
 }
 

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -68,6 +68,7 @@ func TestServer_generateOpenAPI(t *testing.T) {
 	require.Nil(t, document.Paths.Find("/unknown"))
 	require.NotNil(t, document.Paths.Find("/post"))
 	require.Equal(t, document.Paths.Find("/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type, "array")
+	require.Equal(t, document.Paths.Find("/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Items.Ref, "#/components/schemas/MyStruct")
 	require.NotNil(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200"))
 	require.NotNil(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200").Value.Content["application/json"])
 	require.Nil(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value.Properties["unknown"])

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -22,34 +22,34 @@ type MyOutputStruct struct {
 	Quantity int    `json:"quantity"`
 }
 
-func TestTagFromType(t *testing.T) {
-	require.Equal(t, "unknown-interface", tagFromType(*new(any)), "behind any interface")
-	require.Equal(t, "MyStruct", tagFromType(MyStruct{}))
+// func TestTagFromType(t *testing.T) {
+// 	require.Equal(t, "unknown-interface", tagFromType(*new(any)), "behind any interface")
+// 	require.Equal(t, "MyStruct", tagFromType(MyStruct{}))
 
-	t.Run("behind pointers or pointers-like", func(t *testing.T) {
-		require.Equal(t, "MyStruct", tagFromType(&MyStruct{}))
-		require.Equal(t, "MyStruct", tagFromType([]MyStruct{}))
-		require.Equal(t, "MyStruct", tagFromType(&[]MyStruct{}))
-		type DeeplyNested *[]MyStruct
-		require.Equal(t, "MyStruct", tagFromType(new(DeeplyNested)), "behind 4 pointers")
-	})
+// 	t.Run("behind pointers or pointers-like", func(t *testing.T) {
+// 		require.Equal(t, "MyStruct", tagFromType(&MyStruct{}))
+// 		require.Equal(t, "MyStruct", tagFromType([]MyStruct{}))
+// 		require.Equal(t, "MyStruct", tagFromType(&[]MyStruct{}))
+// 		type DeeplyNested *[]MyStruct
+// 		require.Equal(t, "MyStruct", tagFromType(new(DeeplyNested)), "behind 4 pointers")
+// 	})
 
-	t.Run("safety against recursion", func(t *testing.T) {
-		type DeeplyNested *[]MyStruct
-		type MoreDeeplyNested *[]DeeplyNested
-		require.Equal(t, "MyStruct", tagFromType(*new(MoreDeeplyNested)), "behind 5 pointers")
+// 	t.Run("safety against recursion", func(t *testing.T) {
+// 		type DeeplyNested *[]MyStruct
+// 		type MoreDeeplyNested *[]DeeplyNested
+// 		require.Equal(t, "MyStruct", tagFromType(*new(MoreDeeplyNested)), "behind 5 pointers")
 
-		require.Equal(t, "default", tagFromType(new(MoreDeeplyNested)), "behind 6 pointers")
-		require.Equal(t, "default", tagFromType([]*MoreDeeplyNested{}), "behind 7 pointers")
-	})
+// 		require.Equal(t, "default", tagFromType(new(MoreDeeplyNested)), "behind 6 pointers")
+// 		require.Equal(t, "default", tagFromType([]*MoreDeeplyNested{}), "behind 7 pointers")
+// 	})
 
-	t.Run("detecting string", func(t *testing.T) {
-		require.Equal(t, "string", tagFromType("string"))
-		require.Equal(t, "string", tagFromType(new(string)))
-		require.Equal(t, "string", tagFromType([]string{}))
-		require.Equal(t, "string", tagFromType(&[]string{}))
-	})
-}
+// 	t.Run("detecting string", func(t *testing.T) {
+// 		require.Equal(t, "string", tagFromType("string"))
+// 		require.Equal(t, "string", tagFromType(new(string)))
+// 		require.Equal(t, "string", tagFromType([]string{}))
+// 		require.Equal(t, "string", tagFromType(&[]string{}))
+// 	})
+// }
 
 func TestServer_generateOpenAPI(t *testing.T) {
 	s := NewServer()


### PR DESCRIPTION
This did turn out to be pretty complex. 

The following is by no means finished. More looking for a discussion. If you take a look #133 the bug is fairly clear. We do not respect response nor return types when they are arrays. 

The only way I can think of solving this is that we must create the ref to the schema and link it at the bottom of a recursion tree. If you do not do this you will end up with improper refs, with the original approach the input for the first type wins so if an array of `MyStruct` is passed the schema will be a list of `MyStruct` rather than just the simple Schema of `MyStruct`. See `schemaDive`. Currently this does require us to dive twice on request bodies. Since we seem to check request bodies if they are `unknown-type`/`string`, which I am unsure why (wouldn't we want to have []string be a valid requestBody)? As long as that check exists I'm not sure how to avoid both recursive steps. 

This does however give the proper diff
<img width="1305" alt="image" src="https://github.com/go-fuego/fuego/assets/27816957/b01e68a0-c4ae-43a7-a36d-66b5582b8108">

This does need more tests, but I'd like another pair of eyes too look at the approach @EwenQuim if you don't mind. Could you please take a look. I'm sure this can be simplified. I've been staring at it too long at this point. 

@epentland feel free to chime since you brought this to our attention

Thank you