### PR TITLE
BREAKING: all default Send* and Send*Error functions to have the same…

### DIFF
--- a/examples/full-app-gourmet/controller/recipe.go
+++ b/examples/full-app-gourmet/controller/recipe.go
@@ -31,11 +31,11 @@ func (rs recipeRessource) MountRoutes(s *fuego.Server) {
 func (rs recipeRessource) getAllRecipesStandardWithHelpers(w http.ResponseWriter, r *http.Request) {
 	recipes, err := rs.RecipeRepository.GetRecipes(r.Context())
 	if err != nil {
-		fuego.SendJSONError(w, err)
+		fuego.SendJSONError(w, r, err)
 		return
 	}
 
-	fuego.SendJSON(w, recipes)
+	fuego.SendJSON(w, r, recipes)
 }
 
 func (rs recipeRessource) getAllRecipes(c fuego.ContextNoBody) ([]store.Recipe, error) {

--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -42,7 +42,7 @@ func New(config Config) func(http.Handler) http.Handler {
 			}
 
 			w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
-			fuego.SendJSONError(w, err)
+			fuego.SendJSONError(w, nil, err)
 		})
 	}
 }

--- a/options.go
+++ b/options.go
@@ -74,9 +74,9 @@ type Server struct {
 	DisableOpenapi        bool // If true, the routes within the server will not generate an openapi spec.
 	maxBodySize           int64
 
-	Serialize      func(w http.ResponseWriter, r *http.Request, ans any) error // Custom serializer that overrides the default one.
-	SerializeError func(w http.ResponseWriter, r *http.Request, err error)     // Used to serialize the error response. Defaults to [SendError].
-	ErrorHandler   func(err error) error                                       // Used to transform any error into a unified error type structure with status code. Defaults to [ErrorHandler]
+	Serialize      Sender                // Custom serializer that overrides the default one.
+	SerializeError ErrorSender           // Used to serialize the error response. Defaults to [SendError].
+	ErrorHandler   func(err error) error // Used to transform any error into a unified error type structure with status code. Defaults to [ErrorHandler]
 	startTime      time.Time
 
 	OpenAPIConfig OpenAPIConfig
@@ -304,13 +304,15 @@ func WithLogHandler(handler slog.Handler) func(*Server) {
 	}
 }
 
-// WithSerializer sets a custom serializer that overrides the default one.
+// WithSerializer sets a custom serializer of type Sender that overrides the default one.
 // Please send a PR if you think the default serializer should be improved, instead of jumping to this option.
-func WithSerializer(serializer func(w http.ResponseWriter, r *http.Request, ans any) error) func(*Server) {
+func WithSerializer(serializer Sender) func(*Server) {
 	return func(c *Server) { c.Serialize = serializer }
 }
 
-func WithErrorSerializer(serializer func(w http.ResponseWriter, r *http.Request, err error)) func(*Server) {
+// WithErrorSerializer sets a custom serializer of type ErrorSender that overrides the default one.
+// Please send a PR if you think the default serializer should be improved, instead of jumping to this option.
+func WithErrorSerializer(serializer ErrorSender) func(*Server) {
 	return func(c *Server) { c.SerializeError = serializer }
 }
 

--- a/security.go
+++ b/security.go
@@ -212,7 +212,7 @@ func (security Security) TokenToContext(searchFunc ...func(*http.Request) string
 			// Validate the token
 			t, err := security.ValidateToken(token)
 			if err != nil {
-				SendJSONError(w, err)
+				SendJSONError(w, nil, err)
 				return
 			}
 
@@ -306,20 +306,20 @@ func authWall(authorizeFunc func(userRoles ...string) bool) func(next http.Handl
 			// Get the authorizationHeader from the context (set by TokenToContext)
 			claims, err := TokenFromContext(r.Context())
 			if err != nil {
-				SendJSONError(w, ErrUnauthorized)
+				SendJSONError(w, nil, ErrUnauthorized)
 				return
 			}
 
 			// Get the subject and userRoles from the claims
 			userRoles, ok := claims.(jwt.MapClaims)["roles"].([]string)
 			if !ok {
-				SendJSONError(w, ErrInvalidTokenType)
+				SendJSONError(w, nil, ErrInvalidTokenType)
 				return
 			}
 
 			// Check if the user is authorized
 			if !authorizeFunc(userRoles...) {
-				SendJSONError(w, ErrUnauthorized)
+				SendJSONError(w, nil, ErrUnauthorized)
 				return
 			}
 
@@ -369,21 +369,27 @@ func (security Security) StdLoginHandler(verifyUserInfo func(r *http.Request) (j
 	return func(w http.ResponseWriter, r *http.Request) {
 		claims, err := verifyUserInfo(r)
 		if err != nil {
-			SendJSONError(w, err)
+			SendJSONError(w, nil, err)
 			return
 		}
 
 		// Send the token to the cookies
 		token, err := security.GenerateTokenToCookies(claims, w)
 		if err != nil {
-			SendJSONError(w, err)
+			SendJSONError(w, nil, err)
 			return
 		}
 
 		// Send the token to the response
-		SendJSON(w, tokenResponse{
-			Token: token,
-		})
+		// no need to check err as SendJson
+		// responds with a 500 on error to the client
+		_ = SendJSON(
+			w,
+			r,
+			tokenResponse{
+				Token: token,
+			},
+		)
 	}
 }
 
@@ -458,21 +464,27 @@ func (security Security) LoginHandler(verifyUserInfo func(user, password string)
 func (security Security) RefreshHandler(w http.ResponseWriter, r *http.Request) {
 	claims, err := TokenFromContext(r.Context())
 	if err != nil {
-		SendJSONError(w, ErrUnauthorized)
+		SendJSONError(w, nil, ErrUnauthorized)
 		return
 	}
 
 	// Send the token to the cookies
 	token, err := security.GenerateTokenToCookies(claims, w)
 	if err != nil {
-		SendJSONError(w, err)
+		SendJSONError(w, nil, err)
 		return
 	}
 
 	// Send the token to the response
-	SendJSON(w, tokenResponse{
-		Token: token,
-	})
+	// no need to check err as SendJson
+	// responds with a 500 on error to the client
+	_ = SendJSON(
+		w,
+		nil,
+		tokenResponse{
+			Token: token,
+		},
+	)
 }
 
 // RemoveTokenFromCookies generates a JWT token with the given claims and writes it to the cookies.

--- a/security.go
+++ b/security.go
@@ -381,7 +381,7 @@ func (security Security) StdLoginHandler(verifyUserInfo func(r *http.Request) (j
 		}
 
 		// Send the token to the response
-		// no need to check err as SendJson
+		// no need to check err as SendJSON
 		// responds with a 500 on error to the client
 		_ = SendJSON(
 			w,
@@ -476,7 +476,7 @@ func (security Security) RefreshHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Send the token to the response
-	// no need to check err as SendJson
+	// no need to check err as SendJSON
 	// responds with a 500 on error to the client
 	_ = SendJSON(
 		w,

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -262,14 +262,14 @@ func (errorWriter) Header() http.Header {
 func TestSendYaml(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendYAML(w, nil, response{Message: "Hello World", Code: 200})
+		SendYAML(w, nil, response{Message: "Hello World", Code: http.StatusOK})
 
 		require.Equal(t, "message: Hello World\ncode: 200\n", w.Body.String())
 	})
 
 	t.Run("error", func(t *testing.T) {
 		errorWriter := &errorWriter{}
-		SendYAML(errorWriter, nil, response{Message: "Hello World", Code: 200})
+		SendYAML(errorWriter, nil, response{Message: "Hello World", Code: http.StatusOK})
 		require.Contains(t, errorWriter.arg, "Cannot serialize returned response to YAML")
 	})
 }
@@ -277,14 +277,14 @@ func TestSendYaml(t *testing.T) {
 func TestSendJSON(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendJSON(w, nil, response{Message: "Hello World", Code: 200})
+		SendJSON(w, nil, response{Message: "Hello World", Code: http.StatusOK})
 
 		require.Equal(t, crlf(`{"message":"Hello World","code":200}`), w.Body.String())
 	})
 
 	t.Run("error", func(t *testing.T) {
 		errorWriter := &errorWriter{}
-		SendJSON(errorWriter, nil, response{Message: "Hello World", Code: 200})
+		SendJSON(errorWriter, nil, response{Message: "Hello World", Code: http.StatusOK})
 		require.Contains(t, errorWriter.arg, "Cannot serialize returned response to JSON")
 	})
 }

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -30,7 +30,7 @@ func TestRecursiveJSON(t *testing.T) {
 		w := httptest.NewRecorder()
 		value := rec{}
 		value.Rec = &value
-		SendJSON(w, value)
+		SendJSON(w, nil, value)
 
 		require.Equal(t, `{"error":"Cannot serialize returned response to JSON"}`, w.Body.String())
 	})
@@ -39,7 +39,7 @@ func TestRecursiveJSON(t *testing.T) {
 func TestJSON(t *testing.T) {
 	t.Run("can serialize json", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendJSON(w, response{Message: "Hello World", Code: 200})
+		SendJSON(w, nil, response{Message: "Hello World", Code: 200})
 		body := w.Body.String()
 
 		require.Equal(t, crlf(`{"message":"Hello World","code":200}`), body)
@@ -169,7 +169,7 @@ func TestJSONError(t *testing.T) {
 	err := validate(me)
 	w := httptest.NewRecorder()
 	err = ErrorHandler(err)
-	SendJSONError(w, err)
+	SendJSONError(w, nil, err)
 
 	require.JSONEq(t, `
 	{
@@ -239,7 +239,7 @@ func TestJSONError(t *testing.T) {
 
 func TestSend(t *testing.T) {
 	w := httptest.NewRecorder()
-	SendText(w, "Hello World")
+	SendText(w, nil, "Hello World")
 
 	require.Equal(t, "Hello World", w.Body.String())
 }
@@ -262,14 +262,14 @@ func (errorWriter) Header() http.Header {
 func TestSendYaml(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendYAML(w, response{Message: "Hello World", Code: 200})
+		SendYAML(w, nil, response{Message: "Hello World", Code: 200})
 
 		require.Equal(t, "message: Hello World\ncode: 200\n", w.Body.String())
 	})
 
 	t.Run("error", func(t *testing.T) {
 		errorWriter := &errorWriter{}
-		SendYAML(errorWriter, response{Message: "Hello World", Code: 200})
+		SendYAML(errorWriter, nil, response{Message: "Hello World", Code: 200})
 		require.Contains(t, errorWriter.arg, "Cannot serialize returned response to YAML")
 	})
 }
@@ -277,14 +277,14 @@ func TestSendYaml(t *testing.T) {
 func TestSendJSON(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendJSON(w, response{Message: "Hello World", Code: 200})
+		SendJSON(w, nil, response{Message: "Hello World", Code: 200})
 
 		require.Equal(t, crlf(`{"message":"Hello World","code":200}`), w.Body.String())
 	})
 
 	t.Run("error", func(t *testing.T) {
 		errorWriter := &errorWriter{}
-		SendJSON(errorWriter, response{Message: "Hello World", Code: 200})
+		SendJSON(errorWriter, nil, response{Message: "Hello World", Code: 200})
 		require.Contains(t, errorWriter.arg, "Cannot serialize returned response to JSON")
 	})
 }

--- a/tests_test.go
+++ b/tests_test.go
@@ -16,7 +16,7 @@ func TestContentType(t *testing.T) {
 
 	t.Run("Sends application/problem+json when return type is HTTPError", func(t *testing.T) {
 		GetStd(server, "/json-problems", func(w http.ResponseWriter, r *http.Request) {
-			SendJSONError(w, UnauthorizedError{
+			SendJSONError(w, nil, UnauthorizedError{
 				Title: "Unauthorized",
 			})
 		})
@@ -32,7 +32,7 @@ func TestContentType(t *testing.T) {
 
 	t.Run("Sends application/json when return type is not HTTPError", func(t *testing.T) {
 		GetStd(server, "/json", func(w http.ResponseWriter, r *http.Request) {
-			SendJSONError(w, errors.New("error"))
+			SendJSONError(w, nil, errors.New("error"))
 		})
 
 		req := httptest.NewRequest("GET", "/json", nil)


### PR DESCRIPTION
Per: https://github.com/go-fuego/fuego/discussions/162#discussioncomment-10367657

Squaring up all these signatures.