### PR TITLE
feat: attempt to infer a response type when '*/*' is provided

### DIFF
--- a/serialization.go
+++ b/serialization.go
@@ -315,14 +315,19 @@ func InferAcceptHeaderFromType(ans any) string {
 }
 
 func parseAcceptHeader(accept string, ans any) string {
-	if strings.Index(accept, ",") > 0 {
-		accept = accept[:strings.Index(accept, ",")]
-	}
-	if accept == "*/*" {
-		accept = ""
-	}
 	if accept == "" {
-		accept = InferAcceptHeaderFromType(ans)
+		return InferAcceptHeaderFromType(ans)
 	}
-	return accept
+
+	vals := strings.Split(accept, ",")
+	// if the string contains `*/*` try to infer
+	// the header from the type
+	for _, v := range vals {
+		if strings.Contains(v, "*/*") {
+			return InferAcceptHeaderFromType(ans)
+		}
+	}
+
+	// assume the caller wants the first value
+	return vals[0]
 }

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -460,8 +460,18 @@ func TestParseAcceptHeader(t *testing.T) {
 		require.Equal(t, "application/json", accept)
 	})
 
-	t.Run("can infer text/html from a real browser", func(t *testing.T) {
+	t.Run("can infer text/plain from a real browser", func(t *testing.T) {
 		accept := parseAcceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "<h1>Hello World</h1>")
+		require.Equal(t, "text/plain", accept)
+	})
+
+	t.Run("can infer application/json from a real browser", func(t *testing.T) {
+		accept := parseAcceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", response{})
+		require.Equal(t, "application/json", accept)
+	})
+
+	t.Run("can infer text/html from a real browser", func(t *testing.T) {
+		accept := parseAcceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", HTML("Hello World"))
 		require.Equal(t, "text/html", accept)
 	})
 }


### PR DESCRIPTION
Closes #162

There is a bit of a hidden breaking change here. Shown in the test https://github.com/go-fuego/fuego/pull/173/files#diff-95e7bbc519ba50d88c1639d2f79e997f1011f802b8c69605813150752b40c535R463. If we want to maintain the compatibility there's few ways to handle this if we don't want to break the current API:

1. Change `InferAcceptHeaderFromType` `string` and `*string` clause to return `text/html`. `SendHTML` would need to be updated to handle `*string` as well. 
2. Assume if the first value is `text/html` we just parse that - That kinda defeats the whole purpose of trying to infer the type
3. We check if we can render `html` when the first value is `text/html` with like a `canRenderHTML` helper func and if not we then infer the type if `*/*` exists.
4. Do nothing 😄

Also I elected to split and then contains rather than just contains as it just felt better then just doing strings.Contains on the whole string I really don't have a better reason for it. Using just contains would be a small optimization, but if we ever reach the point where we want to sort based upon `Accept-Params` see: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html then we'd need to split anyways. 