### PR TITLE
feat: add route.RequestContentType

### DIFF
--- a/examples/petstore/controllers/pets.go
+++ b/examples/petstore/controllers/pets.go
@@ -19,6 +19,8 @@ func (rs PetsRessources) Routes(s *fuego.Server) {
 	fuego.Get(petsGroup, "/{id}", rs.getPets)
 	fuego.Get(petsGroup, "/by-name/{name...}", rs.getPetByName)
 	fuego.Put(petsGroup, "/{id}", rs.putPets)
+	fuego.Put(petsGroup, "/{id}/json", rs.putPets).
+		RequestContentType("application/json")
 	fuego.Delete(petsGroup, "/{id}", rs.deletePets)
 }
 

--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -632,6 +632,85 @@
 					"pets"
 				]
 			}
+		},
+		"/pets/{id}/json": {
+			"put": {
+				"description": "controller: `github.com/go-fuego/fuego/examples/petstore/controllers.PetsRessources.putPets`\n\n---\n\n",
+				"operationId": "PUT_/pets/:id/json",
+				"parameters": [
+					{
+						"description": "header description",
+						"in": "header",
+						"name": "X-Header",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/PetsUpdate"
+							}
+						}
+					},
+					"description": "Request body for models.PetsUpdate",
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Pets"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Pets"
+								}
+							}
+						},
+						"description": "OK"
+					},
+					"400": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							}
+						},
+						"description": "Bad Request _(validation or deserialization error)_"
+					},
+					"500": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							}
+						},
+						"description": "Internal Server Error _(panics)_"
+					},
+					"default": {
+						"description": ""
+					}
+				},
+				"summary": "put pets",
+				"tags": [
+					"pets"
+				]
+			}
 		}
 	},
 	"servers": [

--- a/openapi_operations.go
+++ b/openapi_operations.go
@@ -92,6 +92,23 @@ func (r Route[ResponseBody, RequestBody]) Tags(tags ...string) Route[ResponseBod
 	return r
 }
 
+// Replace the available request Content-Types for the route.
+// By default, the request Content-Types are `application/json` and `application/xml`
+func (r Route[ResponseBody, RequestBody]) RequestContentType(consumes ...string) Route[ResponseBody, RequestBody] {
+	bodyTag := schemaTagFromType(r.mainRouter, *new(RequestBody))
+
+	if bodyTag.name != "unknown-interface" {
+		requestBody := newRequestBody[RequestBody](bodyTag, consumes)
+
+		// set just Value as we do not want to reference
+		// a global requestBody
+		r.Operation.RequestBody = &openapi3.RequestBodyRef{
+			Value: requestBody,
+		}
+	}
+	return r
+}
+
 // AddTags adds tags to the route.
 func (r Route[ResponseBody, RequestBody]) AddTags(tags ...string) Route[ResponseBody, RequestBody] {
 	r.Operation.Tags = append(r.Operation.Tags, tags...)

--- a/openapi_operations_test.go
+++ b/openapi_operations_test.go
@@ -61,6 +61,35 @@ func TestHeaderParams(t *testing.T) {
 	require.Equal(t, "my description", route.Operation.Parameters.GetByInAndName("header", "my-header").Description)
 }
 
+func TestRequestContentType(t *testing.T) {
+	t.Run("base", func(t *testing.T) {
+		s := NewServer()
+		route := Post(s, "/test", testControllerWithBody).
+			RequestContentType("application/json")
+
+		content := route.Operation.RequestBody.Value.Content
+		require.NotNil(t, content.Get("application/json"))
+		require.Nil(t, content.Get("application/xml"))
+		require.Equal(t, "#/components/schemas/TestRequestBody", content.Get("application/json").Schema.Ref)
+		_, ok := s.OpenApiSpec.Components.RequestBodies["TestRequestBody"]
+		require.True(t, ok)
+	})
+
+	t.Run("variadic", func(t *testing.T) {
+		s := NewServer()
+		route := Post(s, "/test", testControllerWithBody).
+			RequestContentType("application/json", "my/content-type")
+
+		content := route.Operation.RequestBody.Value.Content
+		require.NotNil(t, content.Get("application/json"))
+		require.NotNil(t, content.Get("my/content-type"))
+		require.Nil(t, content.Get("application/xml"))
+		require.Equal(t, "#/components/schemas/TestRequestBody", content.Get("application/json").Schema.Ref)
+		_, ok := s.OpenApiSpec.Components.RequestBodies["TestRequestBody"]
+		require.True(t, ok)
+	})
+}
+
 func TestCustomError(t *testing.T) {
 	type MyError struct {
 		Message string

--- a/serve_test.go
+++ b/serve_test.go
@@ -72,6 +72,23 @@ func testControllerReturningPtrToString(c *ContextNoBody) (*string, error) {
 	return &s, nil
 }
 
+type TestRequestBody struct {
+	A string
+	B int
+}
+
+type TestResponseBody struct {
+	TestRequestBody
+}
+
+func testControllerWithBody(c *ContextWithBody[TestRequestBody]) (*TestResponseBody, error) {
+	body, err := c.Body()
+	if err != nil {
+		return nil, err
+	}
+	return &TestResponseBody{TestRequestBody: body}, nil
+}
+
 func TestHttpHandler(t *testing.T) {
 	s := NewServer()
 


### PR DESCRIPTION
closes #159

Provides the ability for the user to explicitly
set what content types and request body can be.
Maintains the defaullt of `application/json` and `application/xml`