### PR TITLE
fix: enabled misspell flag to golangci-lint to detect typos

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,8 +16,13 @@ linters:
     - staticcheck
     - unused
     - usestdlibvars
+    - misspell
 
 linters-settings:
+  misspell:
+    locale: "US"
+    error: true
+
   gofumpt:
     extra-rules: true
   staticcheck:

--- a/openapi.go
+++ b/openapi.go
@@ -66,7 +66,7 @@ func (s *Server) OutputOpenAPISpec() openapi3.T {
 	// Marshal spec to JSON
 	jsonSpec, err := s.marshalSpec()
 	if err != nil {
-		slog.Error("Error marshalling spec to JSON", "error", err)
+		slog.Error("Error marshaling spec to JSON", "error", err)
 	}
 
 	if !s.OpenAPIConfig.DisableSwagger {


### PR DESCRIPTION
Issue: https://github.com/go-fuego/fuego/issues/188
Fix: Added `misspell` flag to the `golangci-lint`. 
Sample output
<img width="1122" alt="image" src="https://github.com/user-attachments/assets/1fc59e93-46d6-4ea3-91eb-2e23236d6475">

Link to the details of the flag: https://golangci-lint.run/usage/linters/#misspell

