### PR TITLE
ci: add a spellchecker to GitHub CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,7 +6,7 @@ on:
     branches: ["main"]
 
 jobs:
-  markdownlint:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,3 +17,6 @@ jobs:
           files: .
           config_file: .markdownlint.yaml
           dot: true
+
+      - name: typos-action spellchecker
+        uses: crate-ci/typos@v1.24.5

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,8 @@
+[default]
+locale = "en-us"
+
+[files]
+# excluded file
+extend-exclude = [
+   "go.sum", "go.mod", # these files are specific to Go, they shouldn't get parsed for typos
+]

--- a/documentation/src/components/HomepageFeatures/index.tsx
+++ b/documentation/src/components/HomepageFeatures/index.tsx
@@ -5,8 +5,8 @@ export default function HomepageFeatures(): JSX.Element {
   return (
     <div className={styles.features} style={{}}>
       <div id="simple" className={clsx(styles.block, styles.block_odd)}>
-        <h2 className="">Serialisation</h2>
-        <p>Simple serialisation of data structures to JSON and back.</p>
+        <h2 className="">Serialization</h2>
+        <p>Simple serialization of data structures to JSON and back.</p>
       </div>
       <div id="openapi" className={clsx(styles.block)}>
         <h2 className="">OpenAPI generation</h2>


### PR DESCRIPTION
This checker won't detect all typos, but will report the obvious ones.

It's a matter of balance. Too much typos, leads to false-positive.
false-positive leads to maintain a list of exception, quite a pain.

Fixes #188


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a spell-checking process in the CI workflow to enhance code quality by identifying and correcting typographical errors.
	- Added a configuration file to manage typo checks, focusing on relevant files and excluding specific ones.
- **Bug Fixes**
	- Corrected spelling from "Serialisation" to "Serialization" in the HomepageFeatures component for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->