### PR TITLE
Better Accept Serialization

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -106,6 +106,17 @@ func (e ConflictError) StatusCode() int { return http.StatusConflict }
 
 func (e ConflictError) Unwrap() error { return HTTPError(e) }
 
+// NotAcceptableError is an error used to return a 406 status code.
+type NotAcceptableError HTTPError
+
+var _ ErrorWithStatus = NotAcceptableError{}
+
+func (e NotAcceptableError) Error() string { return e.Err.Error() }
+
+func (e NotAcceptableError) StatusCode() int { return http.StatusNotAcceptable }
+
+func (e NotAcceptableError) Unwrap() error { return HTTPError(e) }
+
 // ErrorHandler is the default error handler used by the framework.
 // It transforms any error into the unified error type [HTTPError],
 // Using the [ErrorWithStatus] and [ErrorWithInfo] interfaces.

--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -147,6 +147,13 @@
 				"operationId": "GET_/pets/",
 				"parameters": [
 					{
+						"in": "header",
+						"name": "Accept",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
 						"description": "Number of items per page",
 						"in": "query",
 						"name": "per_page",
@@ -263,6 +270,13 @@
 				"operationId": "POST_/pets/",
 				"parameters": [
 					{
+						"in": "header",
+						"name": "Accept",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
 						"description": "header description",
 						"in": "header",
 						"name": "X-Header",
@@ -343,6 +357,13 @@
 				"description": "controller: `github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.getAllPets`\n\n---\n\nGet all pets",
 				"operationId": "GET_/pets/all",
 				"parameters": [
+					{
+						"in": "header",
+						"name": "Accept",
+						"schema": {
+							"type": "string"
+						}
+					},
 					{
 						"description": "Number of items per page",
 						"in": "query",
@@ -440,6 +461,13 @@
 				"operationId": "GET_/pets/by-age",
 				"parameters": [
 					{
+						"in": "header",
+						"name": "Accept",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
 						"description": "header description",
 						"in": "header",
 						"name": "X-Header",
@@ -512,6 +540,13 @@
 				"operationId": "GET_/pets/by-name/:name...",
 				"parameters": [
 					{
+						"in": "header",
+						"name": "Accept",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
 						"description": "header description",
 						"in": "header",
 						"name": "X-Header",
@@ -581,6 +616,13 @@
 				"operationId": "DELETE_/pets/:id",
 				"parameters": [
 					{
+						"in": "header",
+						"name": "Accept",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
 						"description": "header description",
 						"in": "header",
 						"name": "X-Header",
@@ -647,6 +689,13 @@
 				"operationId": "GET_/pets/:id",
 				"parameters": [
 					{
+						"in": "header",
+						"name": "Accept",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
 						"description": "header description",
 						"in": "header",
 						"name": "X-Header",
@@ -712,6 +761,13 @@
 				"description": "controller: `github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.putPets`\n\n---\n\n",
 				"operationId": "PUT_/pets/:id",
 				"parameters": [
+					{
+						"in": "header",
+						"name": "Accept",
+						"schema": {
+							"type": "string"
+						}
+					},
 					{
 						"description": "header description",
 						"in": "header",
@@ -791,6 +847,13 @@
 				"description": "controller: `github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.putPets`\n\n---\n\n",
 				"operationId": "PUT_/pets/:id/json",
 				"parameters": [
+					{
+						"in": "header",
+						"name": "Accept",
+						"schema": {
+							"type": "string"
+						}
+					},
 					{
 						"description": "header description",
 						"in": "header",

--- a/mux.go
+++ b/mux.go
@@ -187,6 +187,10 @@ func registerFuegoController[T, B any, Contexted ctx[B]](s *Server, method, path
 		route.MainRouter = s
 	}
 
+	acceptHeaderParameter := openapi3.NewHeaderParameter("Accept")
+	acceptHeaderParameter.Schema = openapi3.NewStringSchema().NewRef()
+	route.Operation.AddParameter(acceptHeaderParameter)
+
 	for _, o := range options {
 		o(&route)
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -407,9 +407,12 @@ func TestGroupParams(t *testing.T) {
 	require.Equal(t, group.params, []OpenAPIParam{{Name: "X-Test-Header", Description: "test-value", OpenAPIParamOption: OpenAPIParamOption{Required: true, Example: "example", Type: ""}}})
 
 	document := s.OutputOpenAPISpec()
-	require.Nil(t, document.Paths.Find("/").Get.Parameters)
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "X-Test-Header")
-	require.Equal(t, document.Paths.Find("/api/test2").Get.Parameters[0].Value.Name, "X-Test-Header")
+	require.Len(t, document.Paths.Find("/").Get.Parameters, 1)
+	require.Equal(t, document.Paths.Find("/").Get.Parameters[0].Value.Name, "Accept")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "Accept")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "X-Test-Header")
+	require.Equal(t, document.Paths.Find("/api/test2").Get.Parameters[0].Value.Name, "Accept")
+	require.Equal(t, document.Paths.Find("/api/test2").Get.Parameters[1].Value.Name, "X-Test-Header")
 }
 
 func TestGroupHeaderParams(t *testing.T) {
@@ -421,7 +424,8 @@ func TestGroupHeaderParams(t *testing.T) {
 	require.Equal(t, group.params, []OpenAPIParam{{Name: "X-Test-Header", Description: "test-value", OpenAPIParamOption: OpenAPIParamOption{Required: false, Example: "", Type: HeaderParamType}}})
 
 	document := s.OutputOpenAPISpec()
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "X-Test-Header")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "Accept")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "X-Test-Header")
 }
 
 func TestGroupCookieParams(t *testing.T) {
@@ -433,7 +437,8 @@ func TestGroupCookieParams(t *testing.T) {
 	require.Equal(t, group.params, []OpenAPIParam{{Name: "X-Test-Cookie", Description: "test-value", OpenAPIParamOption: OpenAPIParamOption{Required: false, Example: "", Type: CookieParamType}}})
 
 	document := s.OutputOpenAPISpec()
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "X-Test-Cookie")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "Accept")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "X-Test-Cookie")
 }
 
 func TestGroupQueryParam(t *testing.T) {
@@ -445,7 +450,8 @@ func TestGroupQueryParam(t *testing.T) {
 	require.Equal(t, group.params, []OpenAPIParam{{Name: "X-Test-Query", Description: "test-value", OpenAPIParamOption: OpenAPIParamOption{Required: false, Example: "", Type: QueryParamType}}})
 
 	document := s.OutputOpenAPISpec()
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "X-Test-Query")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "Accept")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "X-Test-Query")
 }
 
 func TestGroupParamsInChildGroup(t *testing.T) {

--- a/serialization.go
+++ b/serialization.go
@@ -159,7 +159,7 @@ var SendJSON = func(w http.ResponseWriter, _ *http.Request, ans any) error {
 		if errors.As(err, &unsupportedType) {
 			return NotAcceptableError{
 				Err:    err,
-				Detail: fmt.Sprintf("Cannot serialize type %s to JSON", unsupportedType.Type),
+				Detail: fmt.Sprintf("Cannot serialize type %T to JSON", ans),
 			}
 		}
 	}

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -97,6 +97,16 @@ func TestXML(t *testing.T) {
 		require.Equal(t, `<response><Message>Hello World</Message><Code>200</Code></response>`, body)
 	})
 
+	t.Run("cannot serialize functions", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		err := SendXML(w, nil, func() {})
+		require.Error(t, err)
+		require.ErrorAs(t, err, &NotAcceptableError{})
+
+		body := w.Body.String()
+		require.Equal(t, "", body)
+	})
+
 	t.Run("can serialize xml error", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		err := HTTPError{Detail: "Hello World"}


### PR DESCRIPTION
This PR does 2 things:

- explicitely declare te Accept Header that we use in Fuego, I don't know why I didn't do it earlier
- Treat serialization errors as a 406 Not Acceptable error