### PR TITLE
ci: no func whitespace

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - run: make lint
+      - run: make lint FIX=""
 
   govulncheck:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,10 +13,11 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - misspell
     - staticcheck
     - unused
     - usestdlibvars
-    - misspell
+    - whitespace
 
 linters-settings:
   misspell:

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,12 @@ fmt:
 	which gofumpt || go install mvdan.cc/gofumpt@latest
 	gofumpt -l -w -extra .
 
+lint-ci: lint
+
+FIX := "--fix"
 lint:
 	which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-	golangci-lint run --fix ./...
+	golangci-lint run ${FIX} ./...
 
 lint-markdown:
 	markdownlint --ignore documentation/node_modules --dot .

--- a/html.go
+++ b/html.go
@@ -68,7 +68,6 @@ var _ CtxRenderer = StdRenderer{}
 
 func (s StdRenderer) Render(ctx context.Context, w io.Writer) error {
 	if strings.Contains(s.templateToExecute, "/") || strings.Contains(s.templateToExecute, "*") {
-
 		s.layoutsGlobs = append(s.layoutsGlobs, s.templateToExecute) // To override all blocks defined in the main template
 		cloned := template.Must(s.templates.Clone())
 		tmpl, err := cloned.ParseFS(s.fs, s.layoutsGlobs...)


### PR DESCRIPTION
Added whitespace linter to ensure no whitespace at start and end of funcs. I don't know why but this annoys. 

Also I've been confused on why main would need to be lint'd sometimes after PRs. So there's an additional commit stopping the fixes in the CI so code moves into main with the proper commit. 