### PR TITLE
Feat/param.required

### DIFF
--- a/ctx_params_test.go
+++ b/ctx_params_test.go
@@ -37,5 +37,22 @@ func TestParam(t *testing.T) {
 			require.Equal(t, http.StatusOK, w.Code)
 			require.Equal(t, "hey18true", w.Body.String())
 		})
+
+	})
+
+	t.Run("Should enforce Required", func(t *testing.T) {
+		s := fuego.NewServer()
+
+		fuego.Get(s, "/test", func(c fuego.ContextNoBody) (string, error) {
+			name := c.QueryParam("name")
+			return name, nil
+		},
+			option.Query("name", "Name", param.Required(), param.Example("example1", "you")),
+		)
+		r := httptest.NewRequest("GET", "/test", nil)
+		w := httptest.NewRecorder()
+		s.Mux.ServeHTTP(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "name is a required query param")
 	})
 }

--- a/examples/petstore/controllers/pets_test.go
+++ b/examples/petstore/controllers/pets_test.go
@@ -16,7 +16,7 @@ func TestGetAllPets(t *testing.T) {
 		s := lib.NewPetStoreServer()
 
 		w := httptest.NewRecorder()
-		r := httptest.NewRequest("GET", "/pets/all", nil)
+		r := httptest.NewRequest("GET", "/pets/all?per_page=5", nil)
 
 		s.Mux.ServeHTTP(w, r)
 
@@ -29,13 +29,13 @@ func TestFilterPets(t *testing.T) {
 		s := lib.NewPetStoreServer()
 
 		w := httptest.NewRecorder()
-		r := httptest.NewRequest("GET", "/pets/?name=kit", nil)
+		r := httptest.NewRequest("GET", "/pets/?name=kit&per_page=5", nil)
 		s.Mux.ServeHTTP(w, r)
 		t.Log(w.Body.String())
 		require.Equal(t, http.StatusOK, w.Code)
 
 		w = httptest.NewRecorder()
-		r = httptest.NewRequest("GET", "/pets/?name=kit&younger_than=1", nil)
+		r = httptest.NewRequest("GET", "/pets/?name=kit&younger_than=1&per_page=5", nil)
 		s.Mux.ServeHTTP(w, r)
 		t.Log(w.Body.String())
 		require.Equal(t, http.StatusOK, w.Code)

--- a/serve_test.go
+++ b/serve_test.go
@@ -81,14 +81,6 @@ type TestResponseBody struct {
 	TestRequestBody
 }
 
-func testControllerWithBody(c *ContextWithBody[TestRequestBody]) (*TestResponseBody, error) {
-	body, err := c.Body()
-	if err != nil {
-		return nil, err
-	}
-	return &TestResponseBody{TestRequestBody: body}, nil
-}
-
 func TestHttpHandler(t *testing.T) {
 	s := NewServer()
 
@@ -359,10 +351,11 @@ func TestIni(t *testing.T) {
 	t.Run("can initialize ContextNoBody", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ctx/error-in-rendering", nil)
 		w := httptest.NewRecorder()
-		ctx := initContext[ContextNoBody](ContextNoBody{
+		ctx, err := initContext[ContextNoBody](ContextNoBody{
 			Req: req,
 			Res: w,
 		})
+		require.NoError(t, err)
 
 		require.NotNil(t, ctx)
 		require.NotNil(t, ctx.Request())
@@ -372,10 +365,11 @@ func TestIni(t *testing.T) {
 	t.Run("can initialize ContextNoBody", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ctx/error-in-rendering", nil)
 		w := httptest.NewRecorder()
-		ctx := initContext[*ContextNoBody](ContextNoBody{
+		ctx, err := initContext[*ContextNoBody](ContextNoBody{
 			Req: req,
 			Res: w,
 		})
+		require.NoError(t, err)
 
 		require.NotNil(t, ctx)
 		require.NotNil(t, ctx.Request())
@@ -385,10 +379,11 @@ func TestIni(t *testing.T) {
 	t.Run("can initialize ContextWithBody[string]", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ctx/error-in-rendering", nil)
 		w := httptest.NewRecorder()
-		ctx := initContext[*ContextWithBody[string]](ContextNoBody{
+		ctx, err := initContext[*ContextWithBody[string]](ContextNoBody{
 			Req: req,
 			Res: w,
 		})
+		require.NoError(t, err)
 
 		require.NotNil(t, ctx)
 		require.NotNil(t, ctx.Request())
@@ -398,10 +393,11 @@ func TestIni(t *testing.T) {
 	t.Run("can initialize ContextWithBody[struct]", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ctx/error-in-rendering", nil)
 		w := httptest.NewRecorder()
-		ctx := initContext[*ContextWithBody[ans]](ContextNoBody{
+		ctx, err := initContext[*ContextWithBody[ans]](ContextNoBody{
 			Req: req,
 			Res: w,
 		})
+		require.NoError(t, err)
 
 		require.NotNil(t, ctx)
 		require.NotNil(t, ctx.Request())


### PR DESCRIPTION
Took a pass at enforcing `Param.Required` at run time. I figured this was the most logical place to do it. My thought is that we `validateContext` will grow in the future? maybe be configurable (I'm not sure)?

I'm open for a conversation on this if this isn't ideal, or there's a better place to put it (it's not the prettiest of code). 

Also. I will say from the splunking I did to implement this. An optimization here would be to store `url.Values` in `ContextNoBody` and expose a func of `URLValues` that returns `url.Values`. This would remove the call of `URL.Query()` in `QueryParam` saving a bit of parsing this could get a  bit expensive for users parsing a lot of params. Let me know if you think it's worth it. I know `Query` isn't the most expensive thing, but it would save something. 