### PR TITLE
Perf/url.values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,6 @@ fmt:
 	which gofumpt || go install mvdan.cc/gofumpt@latest
 	gofumpt -l -w -extra .
 
-lint-ci: lint
-
 FIX := "--fix"
 lint:
 	which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest

--- a/serve.go
+++ b/serve.go
@@ -61,7 +61,7 @@ func validateQueryParams(c ContextNoBody) error {
 			continue
 		}
 
-		if param.Required && !c.Req.URL.Query().Has(k) {
+		if param.Required && !c.urlValues.Has(k) {
 			err := fmt.Errorf("%s is a required query param", k)
 			return BadRequestError{
 				Title:  "Query Param Not Found",
@@ -135,6 +135,7 @@ func HTTPHandler[ReturnType, Body any, Contextable ctx[Body]](s *Server, control
 			fs:        s.fs,
 			templates: templates,
 			params:    route.Params,
+			urlValues: r.URL.Query(),
 		})
 		if err != nil {
 			err = s.ErrorHandler(err)


### PR DESCRIPTION
Stores `url.Values` in context to avoid unneeded calls to `URL.Query()`