### PR TITLE
chore: panic when OptionAddError is supplied more than one type

### DIFF
--- a/option.go
+++ b/option.go
@@ -215,9 +215,14 @@ func OptionDeprecated() func(*BaseRoute) {
 }
 
 // AddError adds an error to the route.
+// Required: should only supply one type to `errorType`
 func OptionAddError(code int, description string, errorType ...any) func(*BaseRoute) {
 	var responseSchema SchemaTag
 	return func(r *BaseRoute) {
+		if len(errorType) > 1 {
+			panic("errorType should not be more than one")
+		}
+
 		if len(errorType) > 0 {
 			responseSchema = SchemaTagFromType(r.mainRouter, errorType[0])
 		} else {

--- a/option_test.go
+++ b/option_test.go
@@ -368,6 +368,14 @@ func TestAddError(t *testing.T) {
 		require.NotNil(t, resp)
 		require.Equal(t, "Conflict: Pet with the same name already exists", *route.Operation.Responses.Value("409").Value.Description)
 	})
+
+	t.Run("should be fatal", func(t *testing.T) {
+		s := fuego.NewServer()
+
+		require.Panics(t, func() {
+			fuego.Get(s, "/test", helloWorld, fuego.OptionAddError(409, "err", Resp{}, Resp{}))
+		})
+	})
 }
 
 func TestHide(t *testing.T) {


### PR DESCRIPTION
Opened this for two reasons. First, this PR.

Saw this today figured we should panic or `slog.Error` with `os.exit`?

---

That being said I noticed that with the default `ErrorHandler` we provide it is not possible to return custom error types as we are always returning `HTTPError` although the OpenAPI spec generated would describe the custom type being in the response. There seems to be two options:

1. Change the default to only return `HTTPError` when it adheres to one of our interfaces. The issue with this though is that we no longer default to RFC 9457 errors format; honestly I'm not really sure it really matters as users need to implement an HTTPErrror or one of our interfaces to really get an RFC 9457 output.
2. Document that in order to add customer error types the caller must override the default ErrorHandler. This could be checked at start time as well.  