### PR TITLE
Remove deprecated params

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -24,7 +24,7 @@ import (
 //		return ans{Ans: "users"}, nil
 //	})
 //	s.Run()
-func Group(s *Server, path string, options ...func(*BaseRoute)) *Server {
+func Group(s *Server, path string, routeOptions ...func(*BaseRoute)) *Server {
 	if path == "/" {
 		path = ""
 	} else if path != "" && path[len(path)-1] == '/' {
@@ -44,7 +44,7 @@ func Group(s *Server, path string, options ...func(*BaseRoute)) *Server {
 		Params:    make(map[string]OpenAPIParam),
 		Operation: openapi3.NewOperation(),
 	}
-	for _, option := range options {
+	for _, option := range routeOptions {
 		option(&baseRoute)
 	}
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -406,16 +406,17 @@ func TestRegister(t *testing.T) {
 					OperationID: "my-operation-id",
 				},
 			},
-		}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).
-			OperationID("new-operation-id").
-			Summary("new-summary").
-			Description("new-description").
-			Tags("new-tag")
+		}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+			OptionOperationID("new-operation-id"),
+			OptionSummary("new-summary"),
+			OptionDescription("new-description"),
+			OptionTags("new-tag"),
+		)
 
 		require.NotNil(t, route)
-		require.Equal(t, []string{"new-tag"}, route.Operation.Tags)
+		require.Equal(t, []string{"my-tag", "new-tag"}, route.Operation.Tags)
 		require.Equal(t, "new-summary", route.Operation.Summary)
-		require.Equal(t, "new-description", route.Operation.Description)
+		require.Equal(t, "controller: `/test`\n\n---\n\nnew-description", route.Operation.Description)
 		require.Equal(t, "new-operation-id", route.Operation.OperationID)
 	})
 }
@@ -451,37 +452,17 @@ func TestGroupTagsOnRoute(t *testing.T) {
 		require.Equal(t, []string{"my-server-tag"}, route.Operation.Tags)
 	})
 
-	t.Run("route tag override", func(t *testing.T) {
-		s := NewServer().
-			Tags("my-server-tag")
-
-		route := Get(s, "/path", func(ctx *ContextNoBody) (string, error) {
-			return "test", nil
-		}).Tags("my-route-tag")
-
-		require.Equal(t, []string{"my-route-tag"}, route.Operation.Tags)
-	})
-
 	t.Run("route tag add", func(t *testing.T) {
 		s := NewServer().
 			Tags("my-server-tag")
 
 		route := Get(s, "/path", func(ctx *ContextNoBody) (string, error) {
 			return "test", nil
-		}).AddTags("my-route-tag")
+		},
+			OptionTags("my-route-tag"),
+		)
 
-		require.Equal(t, []string{"my-server-tag", "my-route-tag"}, route.Operation.Tags)
-	})
-
-	t.Run("route tag removal", func(t *testing.T) {
-		s := NewServer().
-			Tags("my-server-tag")
-
-		route := Get(s, "/path", func(ctx *ContextNoBody) (string, error) {
-			return "test", nil
-		}).AddTags("my-route-tag").RemoveTags("my-server-tag")
-
-		require.Equal(t, []string{"my-route-tag"}, route.Operation.Tags)
+		require.Equal(t, []string{"my-route-tag", "my-server-tag"}, route.Operation.Tags)
 	})
 }
 

--- a/openapi.go
+++ b/openapi.go
@@ -182,7 +182,7 @@ func RegisterOpenAPIOperation[T, B any](s *Server, route Route[T, B]) (*openapi3
 
 	// Response - globals
 	for _, openAPIGlobalResponse := range s.globalOpenAPIResponses {
-		addResponse(s, route.Operation, openAPIGlobalResponse.Code, openAPIGlobalResponse.Description, openAPIGlobalResponse.ErrorType)
+		addResponseIfNotSet(s, route.Operation, openAPIGlobalResponse.Code, openAPIGlobalResponse.Description, openAPIGlobalResponse.ErrorType)
 	}
 
 	// Automatically add non-declared 200 Response

--- a/openapi_operations.go
+++ b/openapi_operations.go
@@ -1,8 +1,6 @@
 package fuego
 
 import (
-	"slices"
-
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
@@ -31,39 +29,6 @@ type OpenAPIParamOption struct {
 	GoType   string // integer, string, bool
 }
 
-// Overrides the description for the route.
-//
-// Deprecated: Use `option.Description` from github.com/go-fuego/fuego/option instead.
-// Example:
-//
-//	fuego.Get(s, "/test", testController, option.Description("my description"))
-func (r Route[ResponseBody, RequestBody]) Description(description string) Route[ResponseBody, RequestBody] {
-	r.Operation.Description = description
-	return r
-}
-
-// Overrides the summary for the route.
-//
-// Deprecated: Use `option.Summary` from github.com/go-fuego/fuego/option instead.
-// Example:
-//
-//	fuego.Get(s, "/test", testController, option.Summary("my summary"))
-func (r Route[ResponseBody, RequestBody]) Summary(summary string) Route[ResponseBody, RequestBody] {
-	r.Operation.Summary = summary
-	return r
-}
-
-// Overrides the operationID for the route.
-//
-// Deprecated: Use `option.OperationID` from github.com/go-fuego/fuego/option instead.
-// Example:
-//
-//	fuego.Get(s, "/test", testController, option.OperationID("my-operation-id"))
-func (r Route[ResponseBody, RequestBody]) OperationID(operationID string) Route[ResponseBody, RequestBody] {
-	r.Operation.OperationID = operationID
-	return r
-}
-
 // Param registers a parameter for the route.
 // The paramType can be "query", "header" or "cookie" as defined in [ParamType].
 // [Cookie], [Header], [QueryParam] are shortcuts for Param.
@@ -84,84 +49,6 @@ func (r Route[ResponseBody, RequestBody]) Param(paramType ParamType, name, descr
 
 	r.Operation.AddParameter(openapiParam)
 
-	return r
-}
-
-// Header registers a header parameter for the route.
-//
-// Deprecated: Use `option.Header` from github.com/go-fuego/fuego/option instead.
-// Example:
-//
-//	fuego.Get(s, "/test", testController, option.Header("my-header", "my description"))
-func (r Route[ResponseBody, RequestBody]) Header(name, description string, params ...OpenAPIParamOption) Route[ResponseBody, RequestBody] {
-	r.Param(HeaderParamType, name, description, params...)
-	return r
-}
-
-// Cookie registers a cookie parameter for the route.
-//
-// Deprecated: Use `option.Cookie` from github.com/go-fuego/fuego/option instead.
-// Example:
-//
-//	fuego.Get(s, "/test", testController, option.Cookie("my-cookie", "my description"))
-func (r Route[ResponseBody, RequestBody]) Cookie(name, description string, params ...OpenAPIParamOption) Route[ResponseBody, RequestBody] {
-	r.Param(CookieParamType, name, description, params...)
-	return r
-}
-
-// QueryParam registers a query parameter for the route.
-//
-// Deprecated: Use `option.Query` from github.com/go-fuego/fuego/option instead.
-// Example:
-//
-//	fuego.Get(s, "/test", testController, option.Query("my-param", "my description"))
-func (r Route[ResponseBody, RequestBody]) QueryParam(name, description string, params ...OpenAPIParamOption) Route[ResponseBody, RequestBody] {
-	r.Param(QueryParamType, name, description, params...)
-	return r
-}
-
-// Replace the tags for the route.
-// By default, the tag is the type of the response body.
-//
-// Deprecated: Use `option.Tags` from github.com/go-fuego/fuego/option instead.
-// Example:
-//
-//	fuego.Get(s, "/test", testController, option.Tags("my-tag"))
-func (r Route[ResponseBody, RequestBody]) Tags(tags ...string) Route[ResponseBody, RequestBody] {
-	r.Operation.Tags = tags
-	return r
-}
-
-// Replace the available request Content-Types for the route.
-// By default, the request Content-Types are `application/json` and `application/xml`
-//
-// Deprecated: Use `option.RequestContentType` from github.com/go-fuego/fuego/option instead.
-// Example:
-//
-//	fuego.Post(s, "/test", testControllerWithBody, option.RequestContentType("application/json"))
-func (r Route[ResponseBody, RequestBody]) RequestContentType(consumes ...string) Route[ResponseBody, RequestBody] {
-	bodyTag := SchemaTagFromType(r.mainRouter, *new(RequestBody))
-
-	if bodyTag.Name != "unknown-interface" {
-		requestBody := newRequestBody[RequestBody](bodyTag, consumes)
-
-		// set just Value as we do not want to reference
-		// a global requestBody
-		r.Operation.RequestBody = &openapi3.RequestBodyRef{
-			Value: requestBody,
-		}
-	}
-	return r
-}
-
-// AddTags adds tags to the route.
-//
-// Deprecated: Use `option.Tags` from github.com/go-fuego/fuego/option instead.
-// Example:
-//
-//	fuego.Get(s, "/test", testController, option.Tags("my-tag"))
-func (r Route[ResponseBody, RequestBody]) AddTags(tags ...string) Route[ResponseBody, RequestBody] {
-	r.Operation.Tags = append(r.Operation.Tags, tags...)
 	return r
 }
 
@@ -195,28 +82,4 @@ type openAPIError struct {
 	Code        int
 	Description string
 	ErrorType   any
-}
-
-// RemoveTags removes tags from the route.
-func (r Route[ResponseBody, RequestBody]) RemoveTags(tags ...string) Route[ResponseBody, RequestBody] {
-	for _, tag := range tags {
-		for i, t := range r.Operation.Tags {
-			if t == tag {
-				r.Operation.Tags = slices.Delete(r.Operation.Tags, i, i+1)
-				break
-			}
-		}
-	}
-	return r
-}
-
-// Deprecated marks the route as deprecated.
-//
-// Deprecated: Use `option.Deprecated` from github.com/go-fuego/fuego/option instead.
-// Example:
-//
-//	fuego.Get(s, "/test", testController, option.Deprecated())
-func (r Route[ResponseBody, RequestBody]) Deprecated() Route[ResponseBody, RequestBody] {
-	r.Operation.Deprecated = true
-	return r
 }

--- a/openapi_operations_test.go
+++ b/openapi_operations_test.go
@@ -54,8 +54,9 @@ func TestCustomError(t *testing.T) {
 		Message string
 	}
 	s := NewServer()
-	route := Get(s, "/test", testController).
-		AddError(400, "My Validation Error", MyError{})
+	route := Get(s, "/test", testController,
+		OptionAddError(400, "My Validation Error", MyError{}),
+	)
 
 	require.Equal(t, "My Validation Error", *route.Operation.Responses.Map()["400"].Value.Description)
 }
@@ -74,12 +75,13 @@ func TestCustomErrorGlobalAndOnRoute(t *testing.T) {
 	}
 
 	routeGlobal := Get(s, "/test-global", testController)
-	routeCustom := Get(s, "/test-custom", testController).
-		AddError(400, "My Local Error", MyLocalError{}).
-		AddError(419, "My Local Teapot")
+	routeCustom := Get(s, "/test-custom", testController,
+		OptionAddError(400, "My Local Error", MyLocalError{}),
+		OptionAddError(419, "My Local Teapot"),
+	)
 
-	require.Equal(t, "My Global Error", *routeGlobal.Operation.Responses.Map()["400"].Value.Description, "Overrides Fuego's default 400 error")
-	require.Equal(t, "Another Global Error", *routeGlobal.Operation.Responses.Map()["501"].Value.Description)
+	require.Equal(t, "My Global Error", *routeGlobal.Operation.Responses.Value("400").Value.Description, "Overrides Fuego's default 400 error")
+	require.Equal(t, "Another Global Error", *routeGlobal.Operation.Responses.Value("501").Value.Description)
 
 	require.Equal(t, "My Local Error", *routeCustom.Operation.Responses.Map()["400"].Value.Description, "Local error overrides global error")
 	require.Equal(t, "My Local Teapot", *routeCustom.Operation.Responses.Map()["419"].Value.Description)

--- a/option.go
+++ b/option.go
@@ -3,6 +3,7 @@ package fuego
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/getkin/kin-openapi/openapi3"
 )
@@ -231,6 +232,7 @@ func OptionDeprecated() func(*BaseRoute) {
 }
 
 // AddError adds an error to the route.
+// It replaces any existing error previously set with the same code.
 // Required: should only supply one type to `errorType`
 func OptionAddError(code int, description string, errorType ...any) func(*BaseRoute) {
 	var responseSchema SchemaTag
@@ -249,7 +251,11 @@ func OptionAddError(code int, description string, errorType ...any) func(*BaseRo
 		response := openapi3.NewResponse().
 			WithDescription(description).
 			WithContent(content)
-		r.Operation.AddResponse(code, response)
+
+		if r.Operation.Responses == nil {
+			r.Operation.Responses = openapi3.NewResponses()
+		}
+		r.Operation.Responses.Set(strconv.Itoa(code), &openapi3.ResponseRef{Value: response})
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -124,17 +124,23 @@ func NewServer(options ...func(*Server)) *Server {
 		Security: NewSecurity(),
 	}
 
+	// Default options that can be overridden
 	defaultOptions := [...]func(*Server){
 		WithAddr("localhost:9999"),
 		WithDisallowUnknownFields(true),
 		WithSerializer(Send),
 		WithErrorSerializer(SendError),
 		WithErrorHandler(ErrorHandler),
+	}
+	options = append(defaultOptions[:], options...)
+
+	// Options set if not provided
+	options = append(options,
 		WithGlobalResponseTypes(http.StatusBadRequest, "Bad Request _(validation or deserialization error)_", HTTPError{}),
 		WithGlobalResponseTypes(http.StatusInternalServerError, "Internal Server Error _(panics)_", HTTPError{}),
-	}
+	)
 
-	for _, option := range append(defaultOptions[:], options...) {
+	for _, option := range options {
 		option(s)
 	}
 
@@ -203,7 +209,7 @@ func WithCorsMiddleware(corsMiddleware func(http.Handler) http.Handler) func(*Se
 }
 
 // WithGlobalResponseTypes adds default response types to the server.
-// useful for adding global error types.
+// Useful for adding global error types.
 // For example:
 //
 //	app := fuego.NewServer(

--- a/server.go
+++ b/server.go
@@ -146,14 +146,23 @@ func NewServer(options ...func(*Server)) *Server {
 	s.startTime = time.Now()
 
 	if s.autoAuth.Enabled {
-		Post(s, "/auth/login", s.Security.LoginHandler(s.autoAuth.VerifyUserInfo)).Tags("Auth").Summary("Login")
-		PostStd(s, "/auth/logout", s.Security.CookieLogoutHandler).Tags("Auth").Summary("Logout")
+		Post(s, "/auth/login", s.Security.LoginHandler(s.autoAuth.VerifyUserInfo),
+			OptionTags("Auth"),
+			OptionSummary("Login"),
+		)
+		PostStd(s, "/auth/logout", s.Security.CookieLogoutHandler,
+			OptionTags("Auth"),
+			OptionSummary("Logout"),
+		)
 
 		s.middlewares = []func(http.Handler) http.Handler{
 			s.Security.TokenToContext(TokenFromCookie, TokenFromHeader),
 		}
 
-		PostStd(s, "/auth/refresh", s.Security.RefreshHandler).Tags("Auth").Summary("Refresh token")
+		PostStd(s, "/auth/refresh", s.Security.RefreshHandler,
+			OptionTags("Auth"),
+			OptionSummary("Refresh"),
+		)
 	}
 
 	return s


### PR DESCRIPTION
Removes deprecated params.

Also fixes the behaviour of `OptionAddError` that was replaced by the global error. We didn't see it when switching to variadic options because the test wasn't made.