### PR TITLE
Refactor route option inheritance

### DIFF
--- a/documentation/docs/guides/openapi.md
+++ b/documentation/docs/guides/openapi.md
@@ -29,7 +29,7 @@ Result for this simple example at [http://localhost:9999/swagger/index.html](htt
 The core idea of Fuego is to generate the OpenAPI specification automatically,
 so you don't have to worry about it. However, you can customize it if you want.
 
-## Operations
+## Route Options
 
 Each route can be customized to add more information to the OpenAPI specification.
 
@@ -53,6 +53,52 @@ func main() {
 		option.Query("name", "Name to greet", param.Required(), param.Default("World")),
 		option.Tags("Hello"),
 		option.Deprecated(),
+	)
+
+	s.Run()
+}
+
+func helloWorld(c fuego.ContextNoBody) (string, error) {
+	return "Hello, World!", nil
+}
+```
+
+## Group Options, Options Groups & Custom Options
+
+You can also customize the OpenAPI specification for a group of routes.
+
+```go
+package main
+
+import (
+	"github.com/go-fuego/fuego"
+	"github.com/go-fuego/fuego/option"
+)
+
+// Define a reusable group of options
+var optionPagination = option.Group(
+	option.QueryInt("page", "Page number", param.Default(1)),
+	option.QueryInt("limit", "Items per page", param.Default(10)),
+)
+
+// Custom options for the group
+var customOption = func(r *fuego.BaseRoute) {
+	r.XXX  = YYY // Direct access to the route struct to inject custom behavior
+}
+
+func main() {
+	s := fuego.NewServer()
+
+	api := fuego.Group(s, "/users",
+		option.Summary("Users routes"),
+		option.Description("Default description for all Users routes"),
+		option.Tags("users"),
+	)
+
+	fuego.Get(api, "/", helloWorld,
+		optionPagination,
+		customOption,
+		option.Summary("A simple hello world"), // Replace the default summary
 	)
 
 	s.Run()

--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -949,5 +949,13 @@
 			"description": "local server",
 			"url": "http://localhost:9999"
 		}
+	],
+	"tags": [
+		{
+			"name": "pets"
+		},
+		{
+			"name": "my-tag"
+		}
 	]
 }

--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -163,6 +163,14 @@
 						}
 					},
 					{
+						"description": "header description",
+						"in": "header",
+						"name": "X-Header",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
 						"description": "Number of items per page",
 						"in": "query",
 						"name": "per_page",
@@ -212,14 +220,6 @@
 						"schema": {
 							"default": 3,
 							"type": "integer"
-						}
-					},
-					{
-						"description": "header description",
-						"in": "header",
-						"name": "X-Header",
-						"schema": {
-							"type": "string"
 						}
 					}
 				],
@@ -374,6 +374,14 @@
 						}
 					},
 					{
+						"description": "header description",
+						"in": "header",
+						"name": "X-Header",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
 						"description": "Number of items per page",
 						"in": "query",
 						"name": "per_page",
@@ -400,14 +408,6 @@
 						"schema": {
 							"default": 1,
 							"type": "integer"
-						}
-					},
-					{
-						"description": "header description",
-						"in": "header",
-						"name": "X-Header",
-						"schema": {
-							"type": "string"
 						}
 					}
 				],
@@ -459,8 +459,8 @@
 				},
 				"summary": "get all pets",
 				"tags": [
-					"my-tag",
-					"pets"
+					"pets",
+					"my-tag"
 				]
 			}
 		},
@@ -705,6 +705,14 @@
 						}
 					},
 					{
+						"description": "header description",
+						"in": "header",
+						"name": "X-Header",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
 						"description": "Pet ID",
 						"examples": {
 							"example": {
@@ -714,14 +722,6 @@
 						"in": "path",
 						"name": "id",
 						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "header description",
-						"in": "header",
-						"name": "X-Header",
 						"schema": {
 							"type": "string"
 						}
@@ -948,11 +948,6 @@
 		{
 			"description": "local server",
 			"url": "http://localhost:9999"
-		}
-	],
-	"tags": [
-		{
-			"name": "pets"
 		}
 	]
 }

--- a/openapi.go
+++ b/openapi.go
@@ -153,19 +153,6 @@ func RegisterOpenAPIOperation[T, B any](s *Server, route Route[T, B]) (*openapi3
 		route.Operation = openapi3.NewOperation()
 	}
 
-	if s.tags != nil {
-		route.Operation.Tags = append(route.Operation.Tags, s.tags...)
-	}
-
-	// Tags
-	if !s.disableAutoGroupTags && s.groupTag != "" {
-		route.Operation.Tags = append(route.Operation.Tags, s.groupTag)
-	}
-
-	for _, param := range s.params {
-		route.Param(param.Type, param.Name, param.Description, param.OpenAPIParamOption)
-	}
-
 	// Request Body
 	if route.Operation.RequestBody == nil {
 		bodyTag := SchemaTagFromType(s, *new(B))

--- a/openapi.go
+++ b/openapi.go
@@ -52,10 +52,26 @@ func (s *Server) Show() *Server {
 	return s
 }
 
+func declareAllTagsFromOperations(s *Server) {
+	for _, pathItem := range s.OpenApiSpec.Paths.Map() {
+		for _, op := range pathItem.Operations() {
+			for _, tag := range op.Tags {
+				if s.OpenApiSpec.Tags.Get(tag) == nil {
+					s.OpenApiSpec.Tags = append(s.OpenApiSpec.Tags, &openapi3.Tag{
+						Name: tag,
+					})
+				}
+			}
+		}
+	}
+}
+
 // OutputOpenAPISpec takes the OpenAPI spec and outputs it to a JSON file and/or serves it on a URL.
 // Also serves a Swagger UI.
 // To modify its behavior, use the [WithOpenAPIConfig] option.
 func (s *Server) OutputOpenAPISpec() openapi3.T {
+	declareAllTagsFromOperations(s)
+
 	// Validate
 	err := s.OpenApiSpec.Validate(context.Background())
 	if err != nil {

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -453,7 +453,7 @@ func TestAutoGroupTags(t *testing.T) {
 	require.NotNil(t, document)
 	require.Nil(t, document.Paths.Find("/a").Get.Tags)
 	require.Equal(t, []string{"group"}, document.Paths.Find("/group/b").Get.Tags)
-	require.Equal(t, []string{"subgroup"}, document.Paths.Find("/group/subgroup/c").Get.Tags)
+	require.Equal(t, []string{"group", "subgroup"}, document.Paths.Find("/group/subgroup/c").Get.Tags)
 	require.Equal(t, []string{"other"}, document.Paths.Find("/other/d").Get.Tags)
 }
 

--- a/option.go
+++ b/option.go
@@ -210,10 +210,22 @@ func OptionSummary(summary string) func(*BaseRoute) {
 	}
 }
 
-// Description adds a description to the route.
+// Description sets the description to the route.
+// By default, the description is set by Fuego with some info,
+// like the controller function name and the package name.
+// If you want to add a description, please use [AddDescription] instead.
 func OptionDescription(description string) func(*BaseRoute) {
 	return func(r *BaseRoute) {
 		r.Operation.Description = description
+	}
+}
+
+// Description appends a description to the route.
+// By default, the description is set by Fuego with some info,
+// like the controller function name and the package name.
+func OptionAddDescription(description string) func(*BaseRoute) {
+	return func(r *BaseRoute) {
+		r.Operation.Description += description
 	}
 }
 

--- a/option/option.go
+++ b/option/option.go
@@ -85,7 +85,15 @@ var Tags = fuego.OptionTags
 var Summary = fuego.OptionSummary
 
 // Description adds a description to the route.
+// By default, the description is set by Fuego with some info,
+// like the controller function name and the package name.
+// If you want to add a description, please use [AddDescription] instead.
 var Description = fuego.OptionDescription
+
+// AddDescription adds a description to the route.
+// By default, the description is set by Fuego with some info,
+// like the controller function name and the package name.
+var AddDescription = fuego.OptionAddDescription
 
 // Security configures security requirements to the route.
 //


### PR DESCRIPTION
Implemented https://github.com/go-fuego/fuego/pull/254#discussion_r1873450220.

Enables to not only inherit param, but all options!

Might enable interesting features in the future.

Makes `WithGlobalResponseTypes` obsolete in favor of stacking a `option.AddError` in the global `WithRouteOptions`