### PR TITLE
Cli/add service generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ coverage.out
 recipe.db
 bin
 go.work.sum
-fuego
+/cmd/fuego/fuego

--- a/cmd/fuego/commands/controller.go
+++ b/cmd/fuego/commands/controller.go
@@ -25,7 +25,12 @@ func Controller() *cli.Command {
 				fmt.Println("Note: You can add a controller name as an argument. Example: `fuego controller books`")
 			}
 
-			_, err := createController(entityName)
+			_, err := createControllerFile(entityName, "entity.go", entityName+".go")
+			if err != nil {
+				return err
+			}
+
+			_, err = createControllerFile(entityName, "controller.go", entityName+"Controller.go")
 			if err != nil {
 				return err
 			}
@@ -37,7 +42,7 @@ func Controller() *cli.Command {
 }
 
 // createController creates a new controller file
-func createController(entityName string) (string, error) {
+func createControllerFile(entityName, controllerTemplateFileName, outputFileName string) (string, error) {
 	controllerDir := "./controller/"
 	if _, err := os.Stat(controllerDir); os.IsNotExist(err) {
 		err = os.Mkdir(controllerDir, 0o755)
@@ -46,7 +51,7 @@ func createController(entityName string) (string, error) {
 		}
 	}
 
-	templateContent, err := templates.FS.ReadFile("controller/controller.go")
+	templateContent, err := templates.FS.ReadFile("controller/" + controllerTemplateFileName)
 	if err != nil {
 		return "", err
 	}
@@ -57,7 +62,7 @@ func createController(entityName string) (string, error) {
 	newContent := strings.ReplaceAll(string(templateContent), "newEntity", entityName)
 	newContent = strings.ReplaceAll(newContent, "NewEntity", titler.String(entityName))
 
-	controllerPath := fmt.Sprintf("%s%s.go", controllerDir, entityName)
+	controllerPath := fmt.Sprintf("%s%s", controllerDir, outputFileName)
 
 	err = os.WriteFile(controllerPath, []byte(newContent), 0o644)
 	if err != nil {

--- a/cmd/fuego/commands/controller.go
+++ b/cmd/fuego/commands/controller.go
@@ -38,6 +38,20 @@ func Controller() *cli.Command {
 			fmt.Printf("🔥 Controller %s created successfully\n", entityName)
 			return nil
 		},
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "with-service",
+				Usage: "enable service file generation",
+				Value: false,
+				Action: func(cCtx *cli.Context, shouldGenerateServiceFile bool) error {
+					if !shouldGenerateServiceFile {
+						return nil
+					}
+
+					return serviceCommandAction(cCtx)
+				},
+			},
+		},
 	}
 }
 

--- a/cmd/fuego/commands/controller.go
+++ b/cmd/fuego/commands/controller.go
@@ -18,26 +18,26 @@ func Controller() *cli.Command {
 		Usage:   "creates a new controller file",
 		Aliases: []string{"c"},
 		Action: func(cCtx *cli.Context) error {
-			controllerName := cCtx.Args().First()
+			entityName := cCtx.Args().First()
 
-			if controllerName == "" {
-				controllerName = "newController"
+			if entityName == "" {
+				entityName = "newEntity"
 				fmt.Println("Note: You can add a controller name as an argument. Example: `fuego controller books`")
 			}
 
-			_, err := createController(controllerName)
+			_, err := createController(entityName)
 			if err != nil {
 				return err
 			}
 
-			fmt.Printf("🔥 Controller %s created successfully\n", controllerName)
+			fmt.Printf("🔥 Controller %s created successfully\n", entityName)
 			return nil
 		},
 	}
 }
 
 // createController creates a new controller file
-func createController(controllerName string) (string, error) {
+func createController(entityName string) (string, error) {
 	controllerDir := "./controller/"
 	if _, err := os.Stat(controllerDir); os.IsNotExist(err) {
 		err = os.Mkdir(controllerDir, 0o755)
@@ -54,10 +54,10 @@ func createController(controllerName string) (string, error) {
 	t := language.English
 	titler := cases.Title(t)
 
-	newContent := strings.ReplaceAll(string(templateContent), "newController", controllerName)
-	newContent = strings.ReplaceAll(newContent, "NewController", titler.String(controllerName))
+	newContent := strings.ReplaceAll(string(templateContent), "newEntity", entityName)
+	newContent = strings.ReplaceAll(newContent, "NewEntity", titler.String(entityName))
 
-	controllerPath := fmt.Sprintf("%s%s.go", controllerDir, controllerName)
+	controllerPath := fmt.Sprintf("%s%s.go", controllerDir, entityName)
 
 	err = os.WriteFile(controllerPath, []byte(newContent), 0o644)
 	if err != nil {

--- a/cmd/fuego/commands/controller.go
+++ b/cmd/fuego/commands/controller.go
@@ -25,12 +25,12 @@ func Controller() *cli.Command {
 				fmt.Println("Note: You can add a controller name as an argument. Example: `fuego controller books`")
 			}
 
-			_, err := createControllerFile(entityName, "entity.go", entityName+".go")
+			_, err := createNewEntityDomainFile(entityName, "entity.go", entityName+".go")
 			if err != nil {
 				return err
 			}
 
-			_, err = createControllerFile(entityName, "controller.go", entityName+"Controller.go")
+			_, err = createNewEntityDomainFile(entityName, "controller.go", entityName+"Controller.go")
 			if err != nil {
 				return err
 			}
@@ -42,16 +42,16 @@ func Controller() *cli.Command {
 }
 
 // createController creates a new controller file
-func createControllerFile(entityName, controllerTemplateFileName, outputFileName string) (string, error) {
-	controllerDir := "./controller/"
+func createNewEntityDomainFile(entityName, controllerTemplateFileName, outputFileName string) (string, error) {
+	controllerDir := "./domains/" + entityName + "/"
 	if _, err := os.Stat(controllerDir); os.IsNotExist(err) {
-		err = os.Mkdir(controllerDir, 0o755)
+		err = os.MkdirAll(controllerDir, 0o755)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	templateContent, err := templates.FS.ReadFile("controller/" + controllerTemplateFileName)
+	templateContent, err := templates.FS.ReadFile("newEntity/" + controllerTemplateFileName)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/fuego/commands/controller_test.go
+++ b/cmd/fuego/commands/controller_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCreateController(t *testing.T) {
-	res, err := createControllerFile("books", "controller.go", "booksController.go")
+	res, err := createNewEntityDomainFile("books", "controller.go", "booksController.go")
 	require.NoError(t, err)
 	require.Contains(t, res, "package controller")
 	require.Contains(t, res, `fuego.Get(booksGroup, "/{id}", rs.getBooks)`)

--- a/cmd/fuego/commands/controller_test.go
+++ b/cmd/fuego/commands/controller_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCreateController(t *testing.T) {
-	res, err := createController("books")
+	res, err := createControllerFile("books", "controller.go", "booksController.go")
 	require.NoError(t, err)
 	require.Contains(t, res, "package controller")
 	require.Contains(t, res, `fuego.Get(booksGroup, "/{id}", rs.getBooks)`)

--- a/cmd/fuego/commands/service.go
+++ b/cmd/fuego/commands/service.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+func Service() *cli.Command {
+	return &cli.Command{
+		Name:    "service",
+		Usage:   "creates a new service file",
+		Aliases: []string{"s"},
+		Action:  serviceCommandAction,
+	}
+}
+
+func serviceCommandAction(cCtx *cli.Context) error {
+	entityName := cCtx.Args().First()
+
+	if entityName == "" {
+		entityName = "newController"
+		fmt.Println("Note: You can add an entity name as an argument. Example: `fuego service books`")
+	}
+
+	_, err := createNewEntityDomainFile(entityName, "entity.go", entityName+".go")
+	if err != nil {
+		return err
+	}
+
+	_, err = createNewEntityDomainFile(entityName, "service.go", entityName+"Service.go")
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("🔥 Service %s created successfully\n", entityName)
+	return nil
+}

--- a/cmd/fuego/main.go
+++ b/cmd/fuego/main.go
@@ -20,6 +20,7 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			commands.Controller(),
+			commands.Service(),
 		},
 	}
 

--- a/cmd/fuego/templates/controller/controller.go
+++ b/cmd/fuego/templates/controller/controller.go
@@ -9,19 +9,6 @@ type NewEntityResources struct {
 	NewEntityService NewEntityService
 }
 
-type NewEntity struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
-
-type NewEntityCreate struct {
-	Name string `json:"name"`
-}
-
-type NewEntityUpdate struct {
-	Name string `json:"name"`
-}
-
 func (rs NewEntityResources) Routes(s *fuego.Server) {
 	newEntityGroup := fuego.Group(s, "/newEntity")
 
@@ -75,12 +62,4 @@ func (rs NewEntityResources) putNewEntity(c *fuego.ContextWithBody[NewEntityUpda
 
 func (rs NewEntityResources) deleteNewEntity(c *fuego.ContextNoBody) (any, error) {
 	return rs.NewEntityService.DeleteNewEntity(c.PathParam("id"))
-}
-
-type NewEntityService interface {
-	GetNewEntity(id string) (NewEntity, error)
-	CreateNewEntity(NewEntityCreate) (NewEntity, error)
-	GetAllNewEntity() ([]NewEntity, error)
-	UpdateNewEntity(id string, input NewEntityUpdate) (NewEntity, error)
-	DeleteNewEntity(id string) (any, error)
 }

--- a/cmd/fuego/templates/controller/controller.go
+++ b/cmd/fuego/templates/controller/controller.go
@@ -4,83 +4,83 @@ import (
 	"github.com/go-fuego/fuego"
 )
 
-type NewControllerResources struct {
+type NewEntityResources struct {
 	// TODO add resources
-	NewControllerService NewControllerService
+	NewEntityService NewEntityService
 }
 
-type NewController struct {
+type NewEntity struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }
 
-type NewControllerCreate struct {
+type NewEntityCreate struct {
 	Name string `json:"name"`
 }
 
-type NewControllerUpdate struct {
+type NewEntityUpdate struct {
 	Name string `json:"name"`
 }
 
-func (rs NewControllerResources) Routes(s *fuego.Server) {
-	newControllerGroup := fuego.Group(s, "/newController")
+func (rs NewEntityResources) Routes(s *fuego.Server) {
+	newEntityGroup := fuego.Group(s, "/newEntity")
 
-	fuego.Get(newControllerGroup, "/", rs.getAllNewController)
-	fuego.Post(newControllerGroup, "/", rs.postNewController)
+	fuego.Get(newEntityGroup, "/", rs.getAllNewEntity)
+	fuego.Post(newEntityGroup, "/", rs.postNewEntity)
 
-	fuego.Get(newControllerGroup, "/{id}", rs.getNewController)
-	fuego.Put(newControllerGroup, "/{id}", rs.putNewController)
-	fuego.Delete(newControllerGroup, "/{id}", rs.deleteNewController)
+	fuego.Get(newEntityGroup, "/{id}", rs.getNewEntity)
+	fuego.Put(newEntityGroup, "/{id}", rs.putNewEntity)
+	fuego.Delete(newEntityGroup, "/{id}", rs.deleteNewEntity)
 }
 
-func (rs NewControllerResources) getAllNewController(c fuego.ContextNoBody) ([]NewController, error) {
-	return rs.NewControllerService.GetAllNewController()
+func (rs NewEntityResources) getAllNewEntity(c fuego.ContextNoBody) ([]NewEntity, error) {
+	return rs.NewEntityService.GetAllNewEntity()
 }
 
-func (rs NewControllerResources) postNewController(c *fuego.ContextWithBody[NewControllerCreate]) (NewController, error) {
+func (rs NewEntityResources) postNewEntity(c *fuego.ContextWithBody[NewEntityCreate]) (NewEntity, error) {
 	body, err := c.Body()
 	if err != nil {
-		return NewController{}, err
+		return NewEntity{}, err
 	}
 
-	new, err := rs.NewControllerService.CreateNewController(body)
+	new, err := rs.NewEntityService.CreateNewEntity(body)
 	if err != nil {
-		return NewController{}, err
+		return NewEntity{}, err
 	}
 
 	return new, nil
 }
 
-func (rs NewControllerResources) getNewController(c fuego.ContextNoBody) (NewController, error) {
+func (rs NewEntityResources) getNewEntity(c fuego.ContextNoBody) (NewEntity, error) {
 	id := c.PathParam("id")
 
-	return rs.NewControllerService.GetNewController(id)
+	return rs.NewEntityService.GetNewEntity(id)
 }
 
-func (rs NewControllerResources) putNewController(c *fuego.ContextWithBody[NewControllerUpdate]) (NewController, error) {
+func (rs NewEntityResources) putNewEntity(c *fuego.ContextWithBody[NewEntityUpdate]) (NewEntity, error) {
 	id := c.PathParam("id")
 
 	body, err := c.Body()
 	if err != nil {
-		return NewController{}, err
+		return NewEntity{}, err
 	}
 
-	new, err := rs.NewControllerService.UpdateNewController(id, body)
+	new, err := rs.NewEntityService.UpdateNewEntity(id, body)
 	if err != nil {
-		return NewController{}, err
+		return NewEntity{}, err
 	}
 
 	return new, nil
 }
 
-func (rs NewControllerResources) deleteNewController(c *fuego.ContextNoBody) (any, error) {
-	return rs.NewControllerService.DeleteNewController(c.PathParam("id"))
+func (rs NewEntityResources) deleteNewEntity(c *fuego.ContextNoBody) (any, error) {
+	return rs.NewEntityService.DeleteNewEntity(c.PathParam("id"))
 }
 
-type NewControllerService interface {
-	GetNewController(id string) (NewController, error)
-	CreateNewController(NewControllerCreate) (NewController, error)
-	GetAllNewController() ([]NewController, error)
-	UpdateNewController(id string, input NewControllerUpdate) (NewController, error)
-	DeleteNewController(id string) (any, error)
+type NewEntityService interface {
+	GetNewEntity(id string) (NewEntity, error)
+	CreateNewEntity(NewEntityCreate) (NewEntity, error)
+	GetAllNewEntity() ([]NewEntity, error)
+	UpdateNewEntity(id string, input NewEntityUpdate) (NewEntity, error)
+	DeleteNewEntity(id string) (any, error)
 }

--- a/cmd/fuego/templates/controller/entity.go
+++ b/cmd/fuego/templates/controller/entity.go
@@ -1,0 +1,22 @@
+package controller
+
+type NewEntity struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type NewEntityCreate struct {
+	Name string `json:"name"`
+}
+
+type NewEntityUpdate struct {
+	Name string `json:"name"`
+}
+
+type NewEntityService interface {
+	GetNewEntity(id string) (NewEntity, error)
+	CreateNewEntity(NewEntityCreate) (NewEntity, error)
+	GetAllNewEntity() ([]NewEntity, error)
+	UpdateNewEntity(id string, input NewEntityUpdate) (NewEntity, error)
+	DeleteNewEntity(id string) (any, error)
+}

--- a/cmd/fuego/templates/newEntity/controller.go
+++ b/cmd/fuego/templates/newEntity/controller.go
@@ -30,12 +30,7 @@ func (rs NewEntityResources) postNewEntity(c *fuego.ContextWithBody[NewEntityCre
 		return NewEntity{}, err
 	}
 
-	new, err := rs.NewEntityService.CreateNewEntity(body)
-	if err != nil {
-		return NewEntity{}, err
-	}
-
-	return new, nil
+	return rs.NewEntityService.CreateNewEntity(body)
 }
 
 func (rs NewEntityResources) getNewEntity(c fuego.ContextNoBody) (NewEntity, error) {
@@ -52,12 +47,7 @@ func (rs NewEntityResources) putNewEntity(c *fuego.ContextWithBody[NewEntityUpda
 		return NewEntity{}, err
 	}
 
-	new, err := rs.NewEntityService.UpdateNewEntity(id, body)
-	if err != nil {
-		return NewEntity{}, err
-	}
-
-	return new, nil
+	return rs.NewEntityService.UpdateNewEntity(id, body)
 }
 
 func (rs NewEntityResources) deleteNewEntity(c *fuego.ContextNoBody) (any, error) {

--- a/cmd/fuego/templates/newEntity/controller.go
+++ b/cmd/fuego/templates/newEntity/controller.go
@@ -1,4 +1,4 @@
-package controller
+package newEntity
 
 import (
 	"github.com/go-fuego/fuego"

--- a/cmd/fuego/templates/newEntity/entity.go
+++ b/cmd/fuego/templates/newEntity/entity.go
@@ -1,4 +1,4 @@
-package controller
+package newEntity
 
 type NewEntity struct {
 	ID   string `json:"id"`

--- a/cmd/fuego/templates/newEntity/service.go
+++ b/cmd/fuego/templates/newEntity/service.go
@@ -1,0 +1,90 @@
+package newEntity
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-fuego/fuego"
+)
+
+type NewEntityServiceImpl struct {
+	newEntityRepository map[string]NewEntity
+	mu                  sync.RWMutex
+}
+
+var _ NewEntityService = &NewEntityServiceImpl{}
+
+func NewNewEntityService() NewEntityService {
+	return &NewEntityServiceImpl{
+		newEntityRepository: make(map[string]NewEntity),
+	}
+}
+
+func (bs *NewEntityServiceImpl) GetNewEntity(id string) (NewEntity, error) {
+	bs.mu.RLock()
+	defer bs.mu.RUnlock()
+
+	newEntity, exists := bs.newEntityRepository[id]
+	if !exists {
+		return NewEntity{}, fuego.NotFoundError{Title: "NewEntity not found with id " + id}
+	}
+
+	return newEntity, nil
+}
+
+func (bs *NewEntityServiceImpl) CreateNewEntity(input NewEntityCreate) (NewEntity, error) {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+
+	id := fmt.Sprintf("%d", time.Now().UnixNano())
+	newEntity := NewEntity{
+		ID:   id,
+		Name: input.Name,
+	}
+
+	bs.newEntityRepository[id] = newEntity
+	return newEntity, nil
+}
+
+func (bs *NewEntityServiceImpl) GetAllNewEntity() ([]NewEntity, error) {
+	bs.mu.RLock()
+	defer bs.mu.RUnlock()
+
+	allNewEntity := make([]NewEntity, 0, len(bs.newEntityRepository))
+	for _, newEntity := range bs.newEntityRepository {
+		allNewEntity = append(allNewEntity, newEntity)
+	}
+
+	return allNewEntity, nil
+}
+
+func (bs *NewEntityServiceImpl) UpdateNewEntity(id string, input NewEntityUpdate) (NewEntity, error) {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+
+	newEntity, exists := bs.newEntityRepository[id]
+	if !exists {
+		return NewEntity{}, fuego.NotFoundError{Title: "NewEntity not found with id " + id}
+	}
+
+	if input.Name != "" {
+		newEntity.Name = input.Name
+	}
+
+	bs.newEntityRepository[id] = newEntity
+	return newEntity, nil
+}
+
+func (bs *NewEntityServiceImpl) DeleteNewEntity(id string) (any, error) {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+
+	_, exists := bs.newEntityRepository[id]
+	if !exists {
+		return nil, fuego.NotFoundError{Title: "NewEntity not found with id " + id}
+	}
+
+	delete(bs.newEntityRepository, id)
+	return "deleted", nil
+}

--- a/documentation/docs/tutorials/02-crud.md
+++ b/documentation/docs/tutorials/02-crud.md
@@ -14,7 +14,13 @@ fuego controller books
 go run github.com/go-fuego/fuego/cmd/fuego@latest controller books
 ```
 
-This generates a controller and a service for the `books` resource.
+This generates a controller for the `books` resource.
+
+:::tip
+
+Use `fuego controller --with-service books` to generate a simple map based in memory service so you can pass it to the controller resources to quickly interact with your new book entity!
+
+:::
 
 You then have to implement the service interface in the controller to be able
 to play with data. It's a form of **dependency injection** that we chose to use


### PR DESCRIPTION
I added on the `fuego controller` cli command a flag (`--with-service`) to generate a simple in memory map based service that satisfies the controller service interface.

The generated service can be pass into the controller resources to have a fully functional CRUD.