### PR TITLE
feat: Prevents empty tags from being added to routes

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -35,8 +35,8 @@ func Group(s *Server, path string, routeOptions ...func(*BaseRoute)) *Server {
 	newServer := &ss
 	newServer.basePath += path
 
-	if !s.disableAutoGroupTags {
-		newServer.routeOptions = append(s.routeOptions, OptionTags(strings.TrimLeft(path, "/")))
+	if autoTag := strings.TrimLeft(path, "/"); !s.disableAutoGroupTags && autoTag != "" {
+		newServer.routeOptions = append(s.routeOptions, OptionTags(autoTag))
 	}
 	newServer.mainRouter = s
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -467,6 +467,17 @@ func TestGroupTagsOnRoute(t *testing.T) {
 
 		require.Equal(t, []string{"my-server-tag", "my-route-tag"}, route.Operation.Tags)
 	})
+
+	t.Run("do not add empty tag group", func(t *testing.T) {
+		s := NewServer()
+		groupEmpty := Group(s, "")
+		groupSlash := Group(s, "/")
+		routeEmpty := Get(groupEmpty, "/empty", dummyController)
+		routeSlash := Get(groupSlash, "/slash", dummyController)
+
+		require.Nil(t, routeEmpty.Operation.Tags)
+		require.Nil(t, routeSlash.Operation.Tags)
+	})
 }
 
 func TestHideOpenapiRoutes(t *testing.T) {


### PR DESCRIPTION
When a group is created with an empty path, the tag should not be added to the route.