### PR TITLE
Adds a direct reference to the OpenAPI object in the BaseRoute object

### DIFF
--- a/option.go
+++ b/option.go
@@ -302,9 +302,9 @@ func OptionAddError(code int, description string, errorType ...any) func(*BaseRo
 		}
 
 		if len(errorType) > 0 {
-			responseSchema = SchemaTagFromType(r.mainRouter.OpenAPI, errorType[0])
+			responseSchema = SchemaTagFromType(r.OpenAPI, errorType[0])
 		} else {
-			responseSchema = SchemaTagFromType(r.mainRouter.OpenAPI, HTTPError{})
+			responseSchema = SchemaTagFromType(r.OpenAPI, HTTPError{})
 		}
 		content := openapi3.NewContentWithSchemaRef(&responseSchema.SchemaRef, []string{"application/json"})
 
@@ -374,14 +374,14 @@ func OptionDefaultStatusCode(defaultStatusCode int) func(*BaseRoute) {
 //	})
 func OptionSecurity(securityRequirements ...openapi3.SecurityRequirement) func(*BaseRoute) {
 	return func(r *BaseRoute) {
-		if r.mainRouter.OpenAPI.Description().Components == nil {
+		if r.OpenAPI.Description().Components == nil {
 			panic("zero security schemes have been registered with the server")
 		}
 
 		// Validate the security scheme exists in components
 		for _, req := range securityRequirements {
 			for schemeName := range req {
-				if _, exists := r.mainRouter.OpenAPI.Description().Components.SecuritySchemes[schemeName]; !exists {
+				if _, exists := r.OpenAPI.Description().Components.SecuritySchemes[schemeName]; !exists {
 					panic(fmt.Sprintf("security scheme '%s' not defined in components", schemeName))
 				}
 			}

--- a/server.go
+++ b/server.go
@@ -56,10 +56,9 @@ type Server struct {
 
 	disableStartupMessages bool
 	disableAutoGroupTags   bool
-	mainRouter             *Server // Ref to the main router (used for groups)
-	basePath               string  // Base path of the group
+	basePath               string // Base path of the group
 
-	// OpenAPI handles the OpenAPI spec generation.
+	// Points to the server OpenAPI struct.
 	OpenAPI *OpenAPI
 
 	Security Security


### PR DESCRIPTION
Instead of referencing the main router and only use OpenAPI field...

Allows to access to the OpenAPI instead of relying on a private net/http server reference that made no sense. Allows progress for #260 

Loving where all this goes, it's getting cleaner and works better.