### PR TITLE
refactor: set openapi server url as close to startup as possible

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -96,7 +96,7 @@ func declareAllTagsFromOperations(s *Server) {
 // To modify its behavior, use the [WithOpenAPIConfig] option.
 func (s *Server) OutputOpenAPISpec() openapi3.T {
 	s.OpenAPI.Description().Servers = append(s.OpenAPI.Description().Servers, &openapi3.Server{
-		URL:         s.proto() + "://" + s.Addr,
+		URL:         s.url(),
 		Description: "local server",
 	})
 
@@ -164,7 +164,7 @@ func (s *Server) registerOpenAPIRoutes(jsonSpec []byte) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(jsonSpec)
 	})
-	s.printOpenAPIMessage(fmt.Sprintf("JSON spec: %s://%s%s", s.proto(), s.Server.Addr, s.OpenAPIConfig.JsonUrl))
+	s.printOpenAPIMessage(fmt.Sprintf("JSON spec: %s%s", s.url(), s.OpenAPIConfig.JsonUrl))
 
 	if !s.OpenAPIConfig.DisableSwaggerUI {
 		Register(s, Route[any, any]{
@@ -173,7 +173,7 @@ func (s *Server) registerOpenAPIRoutes(jsonSpec []byte) {
 				Path:   s.OpenAPIConfig.SwaggerUrl + "/",
 			},
 		}, s.OpenAPIConfig.UIHandler(s.OpenAPIConfig.JsonUrl))
-		s.printOpenAPIMessage(fmt.Sprintf("OpenAPI UI: %s://%s%s/index.html", s.proto(), s.Server.Addr, s.OpenAPIConfig.SwaggerUrl))
+		s.printOpenAPIMessage(fmt.Sprintf("OpenAPI UI: %s%s/index.html", s.url(), s.OpenAPIConfig.SwaggerUrl))
 	}
 }
 

--- a/openapi.go
+++ b/openapi.go
@@ -95,6 +95,11 @@ func declareAllTagsFromOperations(s *Server) {
 // Also serves a Swagger UI.
 // To modify its behavior, use the [WithOpenAPIConfig] option.
 func (s *Server) OutputOpenAPISpec() openapi3.T {
+	s.OpenAPI.Description().Servers = append(s.OpenAPI.Description().Servers, &openapi3.Server{
+		URL:         s.proto() + "//" + s.Addr,
+		Description: "local server",
+	})
+
 	declareAllTagsFromOperations(s)
 
 	// Validate

--- a/openapi.go
+++ b/openapi.go
@@ -96,7 +96,7 @@ func declareAllTagsFromOperations(s *Server) {
 // To modify its behavior, use the [WithOpenAPIConfig] option.
 func (s *Server) OutputOpenAPISpec() openapi3.T {
 	s.OpenAPI.Description().Servers = append(s.OpenAPI.Description().Servers, &openapi3.Server{
-		URL:         s.proto() + "//" + s.Addr,
+		URL:         s.proto() + "://" + s.Addr,
 		Description: "local server",
 	})
 

--- a/serve.go
+++ b/serve.go
@@ -43,7 +43,7 @@ func (s *Server) printStartupMessage() {
 	if !s.disableStartupMessages {
 		elapsed := time.Since(s.startTime)
 		slog.Debug("Server started in "+elapsed.String(), "info", "time between since server creation (fuego.NewServer) and server startup (fuego.Run). Depending on your implementation, there might be things that do not depend on fuego slowing start time")
-		slog.Info("Server running ✅ on "+s.proto()+"://"+s.Server.Addr, "started in", elapsed.String())
+		slog.Info("Server running ✅ on "+s.url(), "started in", elapsed.String())
 	}
 }
 
@@ -52,6 +52,10 @@ func (s *Server) proto() string {
 		return "https"
 	}
 	return "http"
+}
+
+func (s *Server) url() string {
+	return s.proto() + "://" + s.Server.Addr
 }
 
 // initializes any Context type with the base ContextNoBody context.

--- a/server.go
+++ b/server.go
@@ -135,11 +135,6 @@ func NewServer(options ...func(*Server)) *Server {
 		option(s)
 	}
 
-	s.OpenAPI.Description().Servers = append(s.OpenAPI.Description().Servers, &openapi3.Server{
-		URL:         "http://" + s.Addr,
-		Description: "local server",
-	})
-
 	s.startTime = time.Now()
 
 	if s.autoAuth.Enabled {


### PR DESCRIPTION
Closes #248 

Will conflict with https://github.com/go-fuego/fuego/pull/245 but it does solve the issue of creating the server too early so that code could be simplified now I believe. 

Thanks