### PR TITLE
feat: AddResponse 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ golden-update:
 
 # Check OpenAPI spec generated for the Petstore example. Uses https://github.com/daveshanley/vacuum
 openapi-check:
-	vacuum lint -d examples/petstore/testdata/doc/openapi.json
+	vacuum lint -d examples/petstore/lib/testdata/doc/openapi.json
 
 # Examples
 example:

--- a/examples/petstore/controllers/pets_test.go
+++ b/examples/petstore/controllers/pets_test.go
@@ -24,6 +24,19 @@ func TestGetAllPets(t *testing.T) {
 	})
 }
 
+func TestGetAllPetsStd(t *testing.T) {
+	t.Run("can get all pets std", func(t *testing.T) {
+		s := lib.NewPetStoreServer()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/pets/std/all", nil)
+
+		s.Mux.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+}
+
 func TestFilterPets(t *testing.T) {
 	t.Run("can filter pets", func(t *testing.T) {
 		s := lib.NewPetStoreServer()

--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -364,6 +364,11 @@
 								"schema": {
 									"$ref": "#/components/schemas/PetsError"
 								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/PetsError"
+								}
 							}
 						},
 						"description": "Conflict: Pet with the same name already exists"
@@ -670,6 +675,65 @@
 				"summary": "get pet by name",
 				"tags": [
 					"pets"
+				]
+			}
+		},
+		"/pets/std/all": {
+			"get": {
+				"description": "controller: `github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.Routes.func1`\n\n---\n\n",
+				"operationId": "GET_/pets/std/all",
+				"parameters": [
+					{
+						"description": "header description",
+						"in": "header",
+						"name": "X-Header",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"items": {
+										"$ref": "#/components/schemas/Pets"
+									},
+									"type": "array"
+								}
+							}
+						},
+						"description": "all the pets"
+					},
+					"400": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							}
+						},
+						"description": "Bad Request _(validation or deserialization error)_"
+					},
+					"500": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							}
+						},
+						"description": "Internal Server Error _(panics)_"
+					},
+					"default": {
+						"description": ""
+					}
+				},
+				"summary": "func1",
+				"tags": [
+					"pets",
+					"std"
 				]
 			}
 		},
@@ -1007,6 +1071,9 @@
 	"tags": [
 		{
 			"name": "pets"
+		},
+		{
+			"name": "std"
 		},
 		{
 			"name": "my-tag"

--- a/option.go
+++ b/option.go
@@ -294,6 +294,7 @@ func OptionDeprecated() func(*BaseRoute) {
 // AddError adds an error to the route.
 // It replaces any existing error previously set with the same code.
 // Required: should only supply one type to `errorType`
+// Deprecated: Use `OptionAddResponse` instead
 func OptionAddError(code int, description string, errorType ...any) func(*BaseRoute) {
 	var responseSchema SchemaTag
 	return func(r *BaseRoute) {

--- a/option.go
+++ b/option.go
@@ -332,7 +332,7 @@ type Response struct {
 // AddResponse adds a response to a route by status code
 // It replaces any existing response set by any status code, this will override 200.
 // Required: Response.Type must be set
-// Optional: Response.ContentTypes will default to `application/json`, `application/xml` if no set
+// Optional: Response.ContentTypes will default to `application/json` and `application/xml` if not set
 func OptionAddResponse(code int, description string, response Response) func(*BaseRoute) {
 	var responseSchema SchemaTag
 	return func(r *BaseRoute) {

--- a/option/option.go
+++ b/option/option.go
@@ -146,6 +146,7 @@ var OperationID = fuego.OptionOperationID
 var Deprecated = fuego.OptionDeprecated
 
 // AddError adds an error to the route.
+// Deprecated: Use `AddResponse` instead.
 var AddError = fuego.OptionAddError
 
 // AddResponse adds a response to a route by status code

--- a/option/option.go
+++ b/option/option.go
@@ -148,6 +148,12 @@ var Deprecated = fuego.OptionDeprecated
 // AddError adds an error to the route.
 var AddError = fuego.OptionAddError
 
+// AddResponse adds a response to a route by status code
+// It replaces any existing response set by any status code, this will override 200.
+// Required: fuego.Response.Type must be set
+// Optional: fuego.Response.ContentTypes will default to `application/json`, `application/xml` if no set
+var AddResponse = fuego.OptionAddResponse
+
 // RequestContentType sets the accepted content types for the route.
 // By default, the accepted content types is */*.
 // This will override any options set at the server level.

--- a/option/option.go
+++ b/option/option.go
@@ -152,7 +152,7 @@ var AddError = fuego.OptionAddError
 // AddResponse adds a response to a route by status code
 // It replaces any existing response set by any status code, this will override 200.
 // Required: fuego.Response.Type must be set
-// Optional: fuego.Response.ContentTypes will default to `application/json`, `application/xml` if no set
+// Optional: fuego.Response.ContentTypes will default to `application/json` and `application/xml` if not set
 var AddResponse = fuego.OptionAddResponse
 
 // RequestContentType sets the accepted content types for the route.


### PR DESCRIPTION
to allow for setting or overriding of any routes status code

Could really decide whether I wanted to provide a constructor for `fuego.Response` pretty open on that. I did elect to not allow for variadic default of type for 400+ error codes as we discussed in some previous issues/MRs that we shouldn't assuming that all errors are `fuego.HTTPError`'s especially with the recent updates with Default Error Handler.

Also deprecation of AddError in favor of AddResponse.  