### PR TITLE
BREAKING: update WithGlobalResponseType to take

### DIFF
--- a/examples/full-app-gourmet/server/server.go
+++ b/examples/full-app-gourmet/server/server.go
@@ -33,7 +33,7 @@ func (rs Resources) Setup(
 		fuego.WithAutoAuth(controller.LoginFunc),
 		fuego.WithTemplateFS(templates.FS),
 		fuego.WithTemplateGlobs("**/*.html", "**/**/*.html"),
-		fuego.WithGlobalResponseTypes(http.StatusForbidden, "Forbidden"),
+		fuego.WithGlobalResponseTypes(http.StatusForbidden, "Forbidden", fuego.Response{Type: fuego.HTTPError{}}),
 	}
 
 	options = append(serverOptions, options...)

--- a/examples/petstore/lib/server.go
+++ b/examples/petstore/lib/server.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-fuego/fuego"
 	controller "github.com/go-fuego/fuego/examples/petstore/controllers"
 	"github.com/go-fuego/fuego/examples/petstore/services"
+	"github.com/go-fuego/fuego/option"
 )
 
 type NoContent struct {
@@ -13,8 +14,8 @@ type NoContent struct {
 }
 
 func NewPetStoreServer(options ...func(*fuego.Server)) *fuego.Server {
-	options = append(options, fuego.WithGlobalResponseTypes(
-		http.StatusNoContent, "No Content", fuego.Response{Type: NoContent{}},
+	options = append(options, fuego.WithRouteOptions(
+		option.AddResponse(http.StatusNoContent, "No Content", fuego.Response{Type: NoContent{}}),
 	))
 	s := fuego.NewServer(options...)
 

--- a/examples/petstore/lib/server.go
+++ b/examples/petstore/lib/server.go
@@ -1,12 +1,21 @@
 package lib
 
 import (
+	"net/http"
+
 	"github.com/go-fuego/fuego"
 	controller "github.com/go-fuego/fuego/examples/petstore/controllers"
 	"github.com/go-fuego/fuego/examples/petstore/services"
 )
 
+type NoContent struct {
+	Empty string `json:"-"`
+}
+
 func NewPetStoreServer(options ...func(*fuego.Server)) *fuego.Server {
+	options = append(options, fuego.WithGlobalResponseTypes(
+		http.StatusNoContent, "No Content", fuego.Response{Type: NoContent{}},
+	))
 	s := fuego.NewServer(options...)
 
 	petsResources := controller.PetsResources{

--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -51,6 +51,9 @@
 				},
 				"type": "object"
 			},
+			"NoContent": {
+				"description": "NoContent schema"
+			},
 			"Pets": {
 				"description": "Pets schema",
 				"properties": {
@@ -257,6 +260,21 @@
 							}
 						}
 					},
+					"204": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							}
+						},
+						"description": "No Content"
+					},
 					"206": {
 						"description": "OK",
 						"headers": {
@@ -278,6 +296,11 @@
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
 							}
 						},
 						"description": "Bad Request _(validation or deserialization error)_"
@@ -285,6 +308,11 @@
 					"500": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -348,9 +376,29 @@
 						},
 						"description": "Created"
 					},
+					"204": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							}
+						},
+						"description": "No Content"
+					},
 					"400": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -376,6 +424,11 @@
 					"500": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -477,6 +530,21 @@
 							}
 						}
 					},
+					"204": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							}
+						},
+						"description": "No Content"
+					},
 					"206": {
 						"description": "OK",
 						"headers": {
@@ -498,6 +566,11 @@
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
 							}
 						},
 						"description": "Bad Request _(validation or deserialization error)_"
@@ -505,6 +578,11 @@
 					"500": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -572,9 +650,29 @@
 						},
 						"description": "OK"
 					},
+					"204": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							}
+						},
+						"description": "No Content"
+					},
 					"400": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -585,6 +683,11 @@
 					"500": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -648,9 +751,29 @@
 						},
 						"description": "OK"
 					},
+					"204": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							}
+						},
+						"description": "No Content"
+					},
 					"400": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -661,6 +784,11 @@
 					"500": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -706,9 +834,29 @@
 						},
 						"description": "all the pets"
 					},
+					"204": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							}
+						},
+						"description": "No Content"
+					},
 					"400": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -719,6 +867,11 @@
 					"500": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -782,9 +935,29 @@
 						},
 						"description": "OK"
 					},
+					"204": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							}
+						},
+						"description": "No Content"
+					},
 					"400": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -795,6 +968,11 @@
 					"500": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -861,9 +1039,29 @@
 						},
 						"description": "OK"
 					},
+					"204": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							}
+						},
+						"description": "No Content"
+					},
 					"400": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -874,6 +1072,11 @@
 					"500": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -945,9 +1148,29 @@
 						},
 						"description": "OK"
 					},
+					"204": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							}
+						},
+						"description": "No Content"
+					},
 					"400": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -958,6 +1181,11 @@
 					"500": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -1031,9 +1259,29 @@
 						},
 						"description": "OK"
 					},
+					"204": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							}
+						},
+						"description": "No Content"
+					},
 					"400": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}
@@ -1044,6 +1292,11 @@
 					"500": {
 						"content": {
 							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/HTTPError"
 								}

--- a/examples/petstore/main.go
+++ b/examples/petstore/main.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/go-fuego/fuego/examples/petstore/lib"
+import (
+	"github.com/go-fuego/fuego/examples/petstore/lib"
+)
 
 func main() {
 	err := lib.NewPetStoreServer().Run()

--- a/openapi.go
+++ b/openapi.go
@@ -24,7 +24,7 @@ func NewOpenAPI() *OpenAPI {
 	return &OpenAPI{
 		description:            &desc,
 		generator:              openapi3gen.NewGenerator(),
-		globalOpenAPIResponses: []openAPIError{},
+		globalOpenAPIResponses: []openAPIResponse{},
 	}
 }
 
@@ -32,7 +32,7 @@ func NewOpenAPI() *OpenAPI {
 type OpenAPI struct {
 	description            *openapi3.T
 	generator              *openapi3gen.Generator
-	globalOpenAPIResponses []openAPIError
+	globalOpenAPIResponses []openAPIResponse
 }
 
 func (d *OpenAPI) Description() *openapi3.T {
@@ -244,7 +244,13 @@ func RegisterOpenAPIOperation[T, B any](openapi *OpenAPI, route Route[T, B]) (*o
 
 	// Response - globals
 	for _, openAPIGlobalResponse := range openapi.globalOpenAPIResponses {
-		addResponseIfNotSet(openapi, route.Operation, openAPIGlobalResponse.Code, openAPIGlobalResponse.Description, openAPIGlobalResponse.ErrorType)
+		addResponseIfNotSet(
+			openapi,
+			route.Operation,
+			openAPIGlobalResponse.Code,
+			openAPIGlobalResponse.Description,
+			openAPIGlobalResponse.Response,
+		)
 	}
 
 	// Automatically add non-declared 200 (or other) Response

--- a/openapi_operations_test.go
+++ b/openapi_operations_test.go
@@ -98,7 +98,7 @@ func TestWithGlobalResponseType(t *testing.T) {
 		routeGlobal := Get(s, "/test-global", testController)
 		routeCustom := Get(s, "/test-custom", testController,
 			OptionAddResponse(http.StatusBadRequest, "My Local Error", Response{Type: MyLocalResponse{}}),
-			OptionAddError(http.StatusTeapot, "My Local Teapot", Response{Type: HTTPError{}}),
+			OptionAddResponse(http.StatusTeapot, "My Local Teapot", Response{Type: HTTPError{}}),
 		)
 
 		require.Equal(t, "My Global Error", *routeGlobal.Operation.Responses.Value("400").Value.Description, "Overrides Fuego's default 400 error")

--- a/openapi_operations_test.go
+++ b/openapi_operations_test.go
@@ -1,6 +1,7 @@
 package fuego
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -61,32 +62,110 @@ func TestCustomError(t *testing.T) {
 	require.Equal(t, "My Validation Error", *route.Operation.Responses.Map()["400"].Value.Description)
 }
 
-func TestCustomErrorGlobalAndOnRoute(t *testing.T) {
-	type MyGlobalError struct {
+func TestWithGlobalResponseType(t *testing.T) {
+	type MyGlobalResponse struct {
 		Message string
 	}
-	s := NewServer(
-		WithGlobalResponseTypes(400, "My Global Error", MyGlobalError{}),
-		WithGlobalResponseTypes(501, "Another Global Error", MyGlobalError{}),
-	)
-
-	type MyLocalError struct {
+	type MyLocalResponse struct {
 		Message string
 	}
+	t.Run("base", func(t *testing.T) {
+		s := NewServer(
+			WithGlobalResponseTypes(http.StatusNotImplemented, "My Global Error", Response{Type: MyGlobalResponse{}}),
+		)
+		routeGlobal := Get(s, "/test-global", testController)
+		require.Equal(t, "My Global Error", *routeGlobal.Operation.Responses.Value("501").Value.Description)
+	})
 
-	routeGlobal := Get(s, "/test-global", testController)
-	routeCustom := Get(s, "/test-custom", testController,
-		OptionAddError(400, "My Local Error", MyLocalError{}),
-		OptionAddError(419, "My Local Teapot"),
-	)
+	t.Run("base with custom contents", func(t *testing.T) {
+		s := NewServer(
+			WithGlobalResponseTypes(http.StatusNotImplemented, "My Global Error", Response{
+				Type:         MyGlobalResponse{},
+				ContentTypes: []string{"application/x-yaml"},
+			}),
+		)
+		routeGlobal := Get(s, "/test-global", testController)
+		require.NotNil(t, routeGlobal.Operation.Responses.Value("501").Value.Content.Get("application/x-yaml"))
+		require.Nil(t, routeGlobal.Operation.Responses.Value("501").Value.Content.Get("application/xml"))
+	})
 
-	require.Equal(t, "My Global Error", *routeGlobal.Operation.Responses.Value("400").Value.Description, "Overrides Fuego's default 400 error")
-	require.Equal(t, "Another Global Error", *routeGlobal.Operation.Responses.Value("501").Value.Description)
+	t.Run("errors with route overrides", func(t *testing.T) {
+		s := NewServer(
+			WithGlobalResponseTypes(http.StatusBadRequest, "My Global Error", Response{Type: MyGlobalResponse{}}),
+			WithGlobalResponseTypes(http.StatusNotImplemented, "Another Global Error", Response{Type: MyGlobalResponse{}}),
+		)
 
-	require.Equal(t, "My Local Error", *routeCustom.Operation.Responses.Map()["400"].Value.Description, "Local error overrides global error")
-	require.Equal(t, "My Local Teapot", *routeCustom.Operation.Responses.Map()["419"].Value.Description)
-	require.Equal(t, "Internal Server Error _(panics)_", *routeCustom.Operation.Responses.Map()["500"].Value.Description, "Global error set by default by Fuego")
-	require.Equal(t, "Another Global Error", *routeCustom.Operation.Responses.Map()["501"].Value.Description, "Global error is still available")
+		routeGlobal := Get(s, "/test-global", testController)
+		routeCustom := Get(s, "/test-custom", testController,
+			OptionAddResponse(http.StatusBadRequest, "My Local Error", Response{Type: MyLocalResponse{}}),
+			OptionAddError(http.StatusTeapot, "My Local Teapot", Response{Type: HTTPError{}}),
+		)
+
+		require.Equal(t, "My Global Error", *routeGlobal.Operation.Responses.Value("400").Value.Description, "Overrides Fuego's default 400 error")
+		require.Equal(t, "Another Global Error", *routeGlobal.Operation.Responses.Value("501").Value.Description)
+
+		require.Equal(t, "My Local Error", *routeCustom.Operation.Responses.Map()["400"].Value.Description, "Local error overrides global error")
+		require.Equal(t, "My Local Teapot", *routeCustom.Operation.Responses.Map()["418"].Value.Description)
+		require.Equal(t, "Internal Server Error _(panics)_", *routeCustom.Operation.Responses.Map()["500"].Value.Description, "Global error set by default by Fuego")
+		require.Equal(t, "Another Global Error", *routeCustom.Operation.Responses.Map()["501"].Value.Description, "Global error is still available")
+	})
+
+	t.Run("200 responses with overrides", func(t *testing.T) {
+		s := NewServer(
+			WithGlobalResponseTypes(http.StatusCreated, "A Global Response", Response{Type: MyGlobalResponse{}}),
+			WithGlobalResponseTypes(http.StatusAccepted, "My 202 response with content", Response{
+				Type: MyGlobalResponse{}, ContentTypes: []string{"application/x-yaml"},
+			}),
+		)
+
+		t.Run("routeGlobal", func(t *testing.T) {
+			routeGlobal := Get(s, "/test-global", testController)
+			require.Equal(t,
+				"#/components/schemas/ans",
+				routeGlobal.Operation.Responses.Value("200").Value.Content.Get("application/json").Schema.Ref,
+			)
+			require.Equal(t,
+				"#/components/schemas/ans",
+				routeGlobal.Operation.Responses.Value("200").Value.Content.Get("application/xml").Schema.Ref,
+			)
+			require.Equal(t, "A Global Response", *routeGlobal.Operation.Responses.Value("201").Value.Description)
+			require.Equal(t, "My 202 response with content", *routeGlobal.Operation.Responses.Value("202").Value.Description)
+			require.Equal(t,
+				"#/components/schemas/MyGlobalResponse",
+				routeGlobal.Operation.Responses.Value("202").Value.Content.Get("application/x-yaml").Schema.Ref,
+			)
+		})
+
+		t.Run("routeCustom", func(t *testing.T) {
+			routeCustom := Get(s, "/test-custom", testController,
+				OptionAddResponse(http.StatusOK, "My Local Response", Response{Type: MyLocalResponse{}}),
+				OptionAddResponse(http.StatusNoContent, "My No Content", Response{Type: struct{}{}}),
+			)
+			require.Equal(t,
+				"#/components/schemas/MyLocalResponse",
+				routeCustom.Operation.Responses.Value("200").Value.Content.Get("application/json").Schema.Ref,
+			)
+			require.Equal(t,
+				"#/components/schemas/MyLocalResponse",
+				routeCustom.Operation.Responses.Value("200").Value.Content.Get("application/xml").Schema.Ref,
+			)
+			require.Equal(t, "My No Content", *routeCustom.Operation.Responses.Value("204").Value.Description)
+			require.Equal(t, "My 202 response with content", *routeCustom.Operation.Responses.Value("202").Value.Description)
+			require.Equal(t,
+				"#/components/schemas/MyGlobalResponse",
+				routeCustom.Operation.Responses.Value("202").Value.Content.Get("application/x-yaml").Schema.Ref,
+			)
+		})
+	})
+
+	t.Run("should be fatal", func(t *testing.T) {
+		s := NewServer(
+			WithGlobalResponseTypes(http.StatusNotImplemented, "My Global Error", Response{}),
+		)
+		require.Panics(t, func() {
+			Get(s, "/test-global", testController)
+		})
+	})
 }
 
 func TestCookieParams(t *testing.T) {

--- a/option.go
+++ b/option.go
@@ -343,26 +343,15 @@ type Response struct {
 // Required: Response.Type must be set
 // Optional: Response.ContentTypes will default to `application/json` and `application/xml` if not set
 func OptionAddResponse(code int, description string, response Response) func(*BaseRoute) {
-	var responseSchema SchemaTag
 	return func(r *BaseRoute) {
-		if response.Type == nil {
-			panic("Type in Response cannot be nil")
-		}
-
-		responseSchema = SchemaTagFromType(r.OpenAPI, response.Type)
-		if len(response.ContentTypes) == 0 {
-			response.ContentTypes = []string{"application/json", "application/xml"}
-		}
-
-		content := openapi3.NewContentWithSchemaRef(&responseSchema.SchemaRef, response.ContentTypes)
-		response := openapi3.NewResponse().
-			WithDescription(description).
-			WithContent(content)
-
 		if r.Operation.Responses == nil {
 			r.Operation.Responses = openapi3.NewResponses()
 		}
-		r.Operation.Responses.Set(strconv.Itoa(code), &openapi3.ResponseRef{Value: response})
+		r.Operation.Responses.Set(
+			strconv.Itoa(code), &openapi3.ResponseRef{
+				Value: r.OpenAPI.buildOpenapi3Response(description, response),
+			},
+		)
 	}
 }
 

--- a/serve_test.go
+++ b/serve_test.go
@@ -446,7 +446,7 @@ func TestServer_Run(t *testing.T) {
 			s.Mux.ServeHTTP(w, req)
 
 			return w.Body.String() == `OK`
-		}, 5*time.Millisecond, 500*time.Microsecond)
+		}, 5*time.Second, 500*time.Millisecond)
 	})
 }
 

--- a/server.go
+++ b/server.go
@@ -122,11 +122,12 @@ func NewServer(options ...func(*Server)) *Server {
 		WithSerializer(Send),
 		WithErrorSerializer(SendError),
 		WithErrorHandler(ErrorHandler),
-		WithGlobalResponseTypes(http.StatusBadRequest, "Bad Request _(validation or deserialization error)_", Response{Type: HTTPError{}}),
-		WithGlobalResponseTypes(http.StatusInternalServerError, "Internal Server Error _(panics)_", Response{Type: HTTPError{}}),
+		WithRouteOptions(
+			OptionAddResponse(http.StatusBadRequest, "Bad Request _(validation or deserialization error)_", Response{Type: HTTPError{}}),
+			OptionAddResponse(http.StatusInternalServerError, "Internal Server Error _(panics)_", Response{Type: HTTPError{}}),
+		),
 	}
 	options = append(defaultOptions[:], options...)
-
 	for _, option := range options {
 		option(s)
 	}
@@ -199,6 +200,8 @@ func WithCorsMiddleware(corsMiddleware func(http.Handler) http.Handler) func(*Se
 //		fuego.WithGlobalResponseTypes(500, "Internal Server Error _(panics)_", HTTPError{}),
 //		fuego.WithGlobalResponseTypes(204, "No Content", Empty{}),
 //	)
+//
+// Deprecated: Please use [OptionAddResponse] with [WithRouteOptions]
 func WithGlobalResponseTypes(code int, description string, response Response) func(*Server) {
 	return func(c *Server) {
 		WithRouteOptions(

--- a/server.go
+++ b/server.go
@@ -122,14 +122,10 @@ func NewServer(options ...func(*Server)) *Server {
 		WithSerializer(Send),
 		WithErrorSerializer(SendError),
 		WithErrorHandler(ErrorHandler),
-	}
-	options = append(defaultOptions[:], options...)
-
-	// Options set if not provided
-	options = append(options,
 		WithGlobalResponseTypes(http.StatusBadRequest, "Bad Request _(validation or deserialization error)_", Response{Type: HTTPError{}}),
 		WithGlobalResponseTypes(http.StatusInternalServerError, "Internal Server Error _(panics)_", Response{Type: HTTPError{}}),
-	)
+	}
+	options = append(defaultOptions[:], options...)
 
 	for _, option := range options {
 		option(s)
@@ -205,10 +201,9 @@ func WithCorsMiddleware(corsMiddleware func(http.Handler) http.Handler) func(*Se
 //	)
 func WithGlobalResponseTypes(code int, description string, response Response) func(*Server) {
 	return func(c *Server) {
-		c.OpenAPI.globalOpenAPIResponses = append(
-			c.OpenAPI.globalOpenAPIResponses,
-			openAPIResponse{Code: code, Description: description, Response: response},
-		)
+		WithRouteOptions(
+			OptionAddResponse(code, description, response),
+		)(c)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -127,8 +127,8 @@ func NewServer(options ...func(*Server)) *Server {
 
 	// Options set if not provided
 	options = append(options,
-		WithGlobalResponseTypes(http.StatusBadRequest, "Bad Request _(validation or deserialization error)_", HTTPError{}),
-		WithGlobalResponseTypes(http.StatusInternalServerError, "Internal Server Error _(panics)_", HTTPError{}),
+		WithGlobalResponseTypes(http.StatusBadRequest, "Bad Request _(validation or deserialization error)_", Response{Type: HTTPError{}}),
+		WithGlobalResponseTypes(http.StatusInternalServerError, "Internal Server Error _(panics)_", Response{Type: HTTPError{}}),
 	)
 
 	for _, option := range options {
@@ -195,18 +195,20 @@ func WithCorsMiddleware(corsMiddleware func(http.Handler) http.Handler) func(*Se
 }
 
 // WithGlobalResponseTypes adds default response types to the server.
-// Useful for adding global error types.
 // For example:
 //
 //	app := fuego.NewServer(
 //		fuego.WithGlobalResponseTypes(400, "Bad Request _(validation or deserialization error)_", HTTPError{}),
 //		fuego.WithGlobalResponseTypes(401, "Unauthorized _(authentication error)_", HTTPError{}),
 //		fuego.WithGlobalResponseTypes(500, "Internal Server Error _(panics)_", HTTPError{}),
+//		fuego.WithGlobalResponseTypes(204, "No Content", Empty{}),
 //	)
-func WithGlobalResponseTypes(code int, description string, errorType ...any) func(*Server) {
-	errorType = append(errorType, HTTPError{})
+func WithGlobalResponseTypes(code int, description string, response Response) func(*Server) {
 	return func(c *Server) {
-		c.OpenAPI.globalOpenAPIResponses = append(c.OpenAPI.globalOpenAPIResponses, openAPIError{code, description, errorType[0]})
+		c.OpenAPI.globalOpenAPIResponses = append(
+			c.OpenAPI.globalOpenAPIResponses,
+			openAPIResponse{Code: code, Description: description, Response: response},
+		)
 	}
 }
 


### PR DESCRIPTION
Inspired by #274. 

- Changes `WithGlobalResponseType` to use `fuego.Response` as an input
- Defaults `WithGlobalResponseType` inputs to contain `application/json` and `application/xml` closes #247 
- Refactors `WithGlobalResponseType` to use the same helper as `OptionAddResponse` so we can stay in lock step with `fuego.Response` struct

Some notes: 

- I'm not the biggest fan of `openAPIResponse` for a struct name but it's just to hold the global response types until we get to generating the spec. Maybe `GlobalReponse` open to thoughts.
- thoughts on making `addResponseIfNotSet` a method

This was a fun PR. Looking forward to the feedback.

Cheers