### PR TITLE
Refactor, mutualize and document Route object

### DIFF
--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -156,13 +156,6 @@
 				"operationId": "GET_/pets/",
 				"parameters": [
 					{
-						"in": "header",
-						"name": "Accept",
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
 						"description": "header description",
 						"in": "header",
 						"name": "X-Header",
@@ -220,6 +213,13 @@
 						"schema": {
 							"default": 3,
 							"type": "integer"
+						}
+					},
+					{
+						"in": "header",
+						"name": "Accept",
+						"schema": {
+							"type": "string"
 						}
 					}
 				],
@@ -306,16 +306,16 @@
 				"operationId": "POST_/pets/",
 				"parameters": [
 					{
+						"description": "header description",
 						"in": "header",
-						"name": "Accept",
+						"name": "X-Header",
 						"schema": {
 							"type": "string"
 						}
 					},
 					{
-						"description": "header description",
 						"in": "header",
-						"name": "X-Header",
+						"name": "Accept",
 						"schema": {
 							"type": "string"
 						}
@@ -399,13 +399,6 @@
 				"operationId": "GET_/pets/all",
 				"parameters": [
 					{
-						"in": "header",
-						"name": "Accept",
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
 						"description": "header description",
 						"in": "header",
 						"name": "X-Header",
@@ -440,6 +433,13 @@
 						"schema": {
 							"default": 1,
 							"type": "integer"
+						}
+					},
+					{
+						"in": "header",
+						"name": "Accept",
+						"schema": {
+							"type": "string"
 						}
 					}
 				],
@@ -529,16 +529,16 @@
 				"operationId": "GET_/pets/by-age",
 				"parameters": [
 					{
+						"description": "header description",
 						"in": "header",
-						"name": "Accept",
+						"name": "X-Header",
 						"schema": {
 							"type": "string"
 						}
 					},
 					{
-						"description": "header description",
 						"in": "header",
-						"name": "X-Header",
+						"name": "Accept",
 						"schema": {
 							"type": "string"
 						}
@@ -608,16 +608,16 @@
 				"operationId": "GET_/pets/by-name/:name...",
 				"parameters": [
 					{
+						"description": "header description",
 						"in": "header",
-						"name": "Accept",
+						"name": "X-Header",
 						"schema": {
 							"type": "string"
 						}
 					},
 					{
-						"description": "header description",
 						"in": "header",
-						"name": "X-Header",
+						"name": "Accept",
 						"schema": {
 							"type": "string"
 						}
@@ -743,16 +743,16 @@
 				"operationId": "DELETE_/pets/:id",
 				"parameters": [
 					{
+						"description": "header description",
 						"in": "header",
-						"name": "Accept",
+						"name": "X-Header",
 						"schema": {
 							"type": "string"
 						}
 					},
 					{
-						"description": "header description",
 						"in": "header",
-						"name": "X-Header",
+						"name": "Accept",
 						"schema": {
 							"type": "string"
 						}
@@ -816,13 +816,6 @@
 				"operationId": "getPet",
 				"parameters": [
 					{
-						"in": "header",
-						"name": "Accept",
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
 						"description": "header description",
 						"in": "header",
 						"name": "X-Header",
@@ -840,6 +833,13 @@
 						"in": "path",
 						"name": "id",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "header",
+						"name": "Accept",
 						"schema": {
 							"type": "string"
 						}
@@ -895,16 +895,16 @@
 				"operationId": "PUT_/pets/:id",
 				"parameters": [
 					{
+						"description": "header description",
 						"in": "header",
-						"name": "Accept",
+						"name": "X-Header",
 						"schema": {
 							"type": "string"
 						}
 					},
 					{
-						"description": "header description",
 						"in": "header",
-						"name": "X-Header",
+						"name": "Accept",
 						"schema": {
 							"type": "string"
 						}
@@ -981,16 +981,16 @@
 				"operationId": "PUT_/pets/:id/json",
 				"parameters": [
 					{
+						"description": "header description",
 						"in": "header",
-						"name": "Accept",
+						"name": "X-Header",
 						"schema": {
 							"type": "string"
 						}
 					},
 					{
-						"description": "header description",
 						"in": "header",
-						"name": "X-Header",
+						"name": "Accept",
 						"schema": {
 							"type": "string"
 						}

--- a/route.go
+++ b/route.go
@@ -1,0 +1,85 @@
+package fuego
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func NewRoute[T, B any](method, path string, handler any, openapi *OpenAPI, options ...func(*BaseRoute)) Route[T, B] {
+	return Route[T, B]{
+		BaseRoute: NewBaseRoute(method, path, handler, openapi, options...),
+	}
+}
+
+// Route is the main struct for a route in Fuego.
+// It contains the OpenAPI operation and other metadata.
+// It is a wrapper around BaseRoute, with the addition of the response and request body types.
+type Route[ResponseBody any, RequestBody any] struct {
+	BaseRoute
+}
+
+func NewBaseRoute(method, path string, handler any, openapi *OpenAPI, options ...func(*BaseRoute)) BaseRoute {
+	baseRoute := BaseRoute{
+		Method:    method,
+		Path:      path,
+		Params:    make(map[string]OpenAPIParam),
+		FullName:  FuncName(handler),
+		Operation: openapi3.NewOperation(),
+		OpenAPI:   openapi,
+	}
+
+	for _, o := range options {
+		o(&baseRoute)
+	}
+
+	return baseRoute
+}
+
+// BaseRoute is the base struct for all routes in Fuego.
+// It contains the OpenAPI operation and other metadata.
+type BaseRoute struct {
+	// OpenAPI operation
+	Operation *openapi3.Operation
+
+	// HTTP method (GET, POST, PUT, PATCH, DELETE)
+	Method string
+
+	// URL path. Will be prefixed by the base path of the server and the group path if any
+	Path string
+
+	// handler executed for this route
+	Handler http.Handler
+
+	// namespace and name of the function to execute
+	FullName    string
+	Params      map[string]OpenAPIParam
+	Middlewares []func(http.Handler) http.Handler
+
+	// Content types accepted for the request body. If nil, all content types (*/*) are accepted.
+	AcceptedContentTypes []string
+
+	// If true, the route will not be documented in the OpenAPI spec
+	Hidden bool
+
+	// Default status code for the response
+	DefaultStatusCode int
+
+	// Ref to the whole OpenAPI spec. Be careful when changing directly its value directly.
+	OpenAPI *OpenAPI
+
+	// Override the default description
+	overrideDescription bool
+}
+
+func (r *BaseRoute) GenerateDefaultDescription() {
+	if r.overrideDescription {
+		return
+	}
+	r.Operation.Description = DefaultDescription(r.FullName, r.Middlewares) + r.Operation.Description
+}
+
+func (r *BaseRoute) GenerateDefaultOperationID() {
+	r.Operation.OperationID = r.Method + "_" + strings.ReplaceAll(strings.ReplaceAll(r.Path, "{", ":"), "}", "")
+}

--- a/server_test.go
+++ b/server_test.go
@@ -378,10 +378,10 @@ func TestGroupParams(t *testing.T) {
 	t.Log(document.Paths.Find("/").Get.Parameters[0].Value.Name)
 	require.Len(t, document.Paths.Find("/").Get.Parameters, 1)
 	require.Equal(t, document.Paths.Find("/").Get.Parameters[0].Value.Name, "Accept")
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "Accept")
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "X-Test-Header")
-	require.Equal(t, document.Paths.Find("/api/test2").Get.Parameters[0].Value.Name, "Accept")
-	require.Equal(t, document.Paths.Find("/api/test2").Get.Parameters[1].Value.Name, "X-Test-Header")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "Accept")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "X-Test-Header")
+	require.Equal(t, document.Paths.Find("/api/test2").Get.Parameters[1].Value.Name, "Accept")
+	require.Equal(t, document.Paths.Find("/api/test2").Get.Parameters[0].Value.Name, "X-Test-Header")
 }
 
 func TestGroupHeaderParams(t *testing.T) {
@@ -395,8 +395,8 @@ func TestGroupHeaderParams(t *testing.T) {
 	require.Equal(t, "test-value", route.Operation.Parameters.GetByInAndName("header", "X-Test-Header").Description)
 
 	document := s.OutputOpenAPISpec()
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "Accept")
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "X-Test-Header")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "Accept")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "X-Test-Header")
 }
 
 func TestGroupCookieParams(t *testing.T) {
@@ -410,8 +410,8 @@ func TestGroupCookieParams(t *testing.T) {
 	require.Equal(t, "test-value", route.Operation.Parameters.GetByInAndName("cookie", "X-Test-Cookie").Description)
 
 	document := s.OutputOpenAPISpec()
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "Accept")
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "X-Test-Cookie")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "Accept")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "X-Test-Cookie")
 }
 
 func TestGroupQueryParam(t *testing.T) {
@@ -425,8 +425,8 @@ func TestGroupQueryParam(t *testing.T) {
 	require.Equal(t, "test-value", route.Operation.Parameters.GetByInAndName("query", "X-Test-Query").Description)
 
 	document := s.OutputOpenAPISpec()
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "Accept")
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "X-Test-Query")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "Accept")
+	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "X-Test-Query")
 }
 
 func TestGroupParamsInChildGroup(t *testing.T) {


### PR DESCRIPTION
Allow to centralize the route object creation : less code duplication, usable from the Gin compat package, and also documented the Route object.

Not the most important PR to be honest, but it cleans the code and make it cleaner.