### PR TITLE
chore: remove previously deprecated WithPort

### DIFF
--- a/documentation/docs/guides/options.md
+++ b/documentation/docs/guides/options.md
@@ -41,22 +41,6 @@ func main() {
 }
 ```
 
-### Port (Deprecated)
-
-**Deprecated** in favor of `WithAddr` shown above.
-
-You can change the port of the server with the `WithPort` option.
-
-```go
-import "github.com/go-fuego/fuego"
-
-func main() {
-	s := fuego.NewServer(
-		fuego.WithPort(8080),
-	)
-}
-```
-
 ### CORS
 
 CORS middleware is not registered as a usual middleware,

--- a/server.go
+++ b/server.go
@@ -1,7 +1,6 @@
 package fuego
 
 import (
-	"fmt"
 	"html/template"
 	"io"
 	"io/fs"
@@ -302,15 +301,6 @@ func WithAutoAuth(verifyUserInfo func(user, password string) (jwt.Claims, error)
 // Defaults to true.
 func WithDisallowUnknownFields(b bool) func(*Server) {
 	return func(c *Server) { c.DisallowUnknownFields = b }
-}
-
-// WithPort sets the port of the server. For example, 8080.
-// If not specified, the default port is 9999.
-// If you want to use a different address, use [WithAddr] instead.
-//
-// Deprecated: Please use [WithAddr]
-func WithPort(port int) func(*Server) {
-	return func(s *Server) { s.Server.Addr = fmt.Sprintf("localhost:%d", port) }
 }
 
 // WithAddr optionally specifies the TCP address for the server to listen on, in the form "host:port".

--- a/server_test.go
+++ b/server_test.go
@@ -263,20 +263,6 @@ func TestWithAddr(t *testing.T) {
 	}
 }
 
-func TestWithPort(t *testing.T) {
-	t.Run("with custom port, that port is used", func(t *testing.T) {
-		s := NewServer(
-			WithPort(8488),
-		)
-		require.Equal(t, "localhost:8488", s.Server.Addr)
-	})
-
-	t.Run("no port provided, default is used (9999)", func(t *testing.T) {
-		s := NewServer()
-		require.Equal(t, "localhost:9999", s.Server.Addr)
-	})
-}
-
 func TestWithoutStartupMessages(t *testing.T) {
 	s := NewServer(
 		WithoutStartupMessages(),


### PR DESCRIPTION
I figured it's time for this. It's been like 4 maybe 5 releases.