### PR TITLE
Moved all non-net/http related code to the new Engine struct

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -1,0 +1,16 @@
+package fuego
+
+func NewEngine() *Engine {
+	return &Engine{
+		OpenAPI:      NewOpenAPI(),
+		ErrorHandler: ErrorHandler,
+	}
+}
+
+// The Engine is the main struct of the framework.
+type Engine struct {
+	OpenAPI      *OpenAPI
+	ErrorHandler func(error) error
+
+	acceptedContentTypes []string
+}


### PR DESCRIPTION
As the title says.

It's not a lot haha, and we could have expected this, because we're really close to `net/http`. The next step will be to fit our Content-Negociation into this Engine. But we'll release the Gin compatibility package before as it's not the end if it only supports `application/json` for a few weeks.