### PR TITLE
Optionshow

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -86,7 +86,7 @@ func Register[T, B any](s *Server, route Route[T, B], controller http.Handler, o
 	route.Middlewares = append(s.middlewares, route.Middlewares...)
 	s.Mux.Handle(fullPath, withMiddlewares(route.Handler, route.Middlewares...))
 
-	if s.DisableOpenapi || route.Hidden || route.Method == "" {
+	if route.Hidden || route.Method == "" {
 		return &route
 	}
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -487,7 +487,6 @@ func TestHideOpenapiRoutes(t *testing.T) {
 		s.Hide()
 		Get(s, "/test", func(ctx ContextNoBody) (string, error) { return "", nil })
 
-		require.Equal(t, s.DisableOpenapi, true)
 		require.True(t, s.OpenAPI.Description().Paths.Find("/not-hidden") != nil)
 		require.True(t, s.OpenAPI.Description().Paths.Find("/test") == nil)
 	})
@@ -499,7 +498,6 @@ func TestHideOpenapiRoutes(t *testing.T) {
 		g := Group(s, "/group").Hide()
 		Get(g, "/test", func(ctx ContextNoBody) (string, error) { return "", nil })
 
-		require.Equal(t, g.DisableOpenapi, true)
 		require.True(t, s.OpenAPI.Description().Paths.Find("/not-hidden") != nil)
 		require.True(t, s.OpenAPI.Description().Paths.Find("/group/test") == nil)
 	})
@@ -512,8 +510,6 @@ func TestHideOpenapiRoutes(t *testing.T) {
 		g2 := Group(s, "/group2")
 		Get(g2, "/test", func(ctx ContextNoBody) (string, error) { return "test", nil })
 
-		require.Equal(t, true, g.DisableOpenapi)
-		require.Equal(t, false, g2.DisableOpenapi)
 		require.True(t, s.OpenAPI.Description().Paths.Find("/group/test") == nil)
 		require.True(t, s.OpenAPI.Description().Paths.Find("/group2/test") != nil)
 	})
@@ -526,7 +522,6 @@ func TestHideOpenapiRoutes(t *testing.T) {
 		g2 := Group(g, "/sub").Show()
 		Get(g2, "/test", func(ctx ContextNoBody) (string, error) { return "test", nil })
 
-		require.Equal(t, true, g.DisableOpenapi)
 		require.True(t, s.OpenAPI.Description().Paths.Find("/group/test") == nil)
 		require.True(t, s.OpenAPI.Description().Paths.Find("/group/sub/test") != nil)
 	})

--- a/openapi.go
+++ b/openapi.go
@@ -85,15 +85,21 @@ func NewOpenApiSpec() openapi3.T {
 }
 
 // Hide prevents the routes in this server or group from being included in the OpenAPI spec.
+// Deprecated: Please use [OptionHide] with [WithRouteOptions]
 func (s *Server) Hide() *Server {
-	s.DisableOpenapi = true
+	WithRouteOptions(
+		OptionHide(),
+	)(s)
 	return s
 }
 
 // Show allows displaying the routes. Activated by default so useless in most cases,
 // but this can be useful if you deactivated the parent group.
+// Deprecated: Please use [OptionShow] with [WithRouteOptions]
 func (s *Server) Show() *Server {
-	s.DisableOpenapi = false
+	WithRouteOptions(
+		OptionShow(),
+	)(s)
 	return s
 }
 

--- a/option.go
+++ b/option.go
@@ -371,6 +371,13 @@ func OptionHide() func(*BaseRoute) {
 	}
 }
 
+// Show shows the route from the OpenAPI spec.
+func OptionShow() func(*BaseRoute) {
+	return func(r *BaseRoute) {
+		r.Hidden = false
+	}
+}
+
 // OptionDefaultStatusCode sets the default status code for the route.
 func OptionDefaultStatusCode(defaultStatusCode int) func(*BaseRoute) {
 	return func(r *BaseRoute) {

--- a/option/option.go
+++ b/option/option.go
@@ -170,5 +170,8 @@ var RequestContentType = fuego.OptionRequestContentType
 // Hide hides the route from the OpenAPI spec.
 var Hide = fuego.OptionHide
 
+// Hide hides the route from the OpenAPI spec.
+var Show = fuego.OptionShow
+
 // DefaultStatusCode sets the default status code for the route.
 var DefaultStatusCode = fuego.OptionDefaultStatusCode

--- a/option/option.go
+++ b/option/option.go
@@ -170,7 +170,7 @@ var RequestContentType = fuego.OptionRequestContentType
 // Hide hides the route from the OpenAPI spec.
 var Hide = fuego.OptionHide
 
-// Hide hides the route from the OpenAPI spec.
+// Show shows the route from the OpenAPI spec.
 var Show = fuego.OptionShow
 
 // DefaultStatusCode sets the default status code for the route.

--- a/server.go
+++ b/server.go
@@ -64,8 +64,6 @@ type Server struct {
 	fs       fs.FS
 	template *template.Template // TODO: use preparsed templates
 
-	acceptedContentTypes []string
-
 	// If true, the server will return an error if the request body contains unknown fields. Useful for quick debugging in development.
 	DisallowUnknownFields bool
 	maxBodySize           int64

--- a/server.go
+++ b/server.go
@@ -64,8 +64,10 @@ type Server struct {
 	fs       fs.FS
 	template *template.Template // TODO: use preparsed templates
 
-	DisallowUnknownFields bool // If true, the server will return an error if the request body contains unknown fields. Useful for quick debugging in development.
-	DisableOpenapi        bool // If true, the routes within the server will not generate an OpenAPI spec.
+	acceptedContentTypes []string
+
+	// If true, the server will return an error if the request body contains unknown fields. Useful for quick debugging in development.
+	DisallowUnknownFields bool
 	maxBodySize           int64
 
 	// Custom serializer that overrides the default one.


### PR DESCRIPTION
Closes #270

This doesn't follow the theme of what #270 was saying but I believe it covers it. If we were to do `fuego.OptionShowInOpenAPI(bool)`. I say we should deprecate `OptionHide` in favor of use `fuego.OptionShowInOpenAPI(bool)`. 

Either way one hidden feature with this pull request is that it now allows for users to hide at the group level but also show a route in that group