### PR TITLE
[skip ci] - WIP req resp logger

### DIFF
--- a/default_middlewares.go
+++ b/default_middlewares.go
@@ -1,0 +1,22 @@
+package fuego
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+func (l *RequestResponseLogger) Log(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		l.request(w, r)
+		next.ServeHTTP(w, r)
+		l.response(w, r)
+	})
+}
+
+func RequestLog(w http.ResponseWriter, r *http.Request) {
+	slog.Info("request")
+}
+
+func ResponseLog(w http.ResponseWriter, r *http.Request) {
+	slog.Info("response")
+}


### PR DESCRIPTION
Looking for some feedback on this idea for the UI of setting/disabling a request response logger. 

`WithRequestResponseLog(nil)` - Would disable middleware logging completely and not register the middleware

`WithRequestResponseLog(NewRequestResponseLog(RequestLog, nil))` - Would set the default log on request time

`WithRequestResponseLog(NewRequestResponseLog(nil, ResponseLog))` - Would set the default log at response. 

I believe this also should be move to `Server.Engine`