### PR TITLE
chore: comment Deprecatd -> OptionDeprecated

### DIFF
--- a/option.go
+++ b/option.go
@@ -293,7 +293,7 @@ func OptionOperationID(operationID string) func(*BaseRoute) {
 	}
 }
 
-// Deprecated marks the route as deprecated.
+// OptionDeprecated marks the route as deprecated.
 func OptionDeprecated() func(*BaseRoute) {
 	return func(r *BaseRoute) {
 		r.Operation.Deprecated = true


### PR DESCRIPTION
My developer tools complain about this being deprecated when it isn't. Not sure if there is a better way to avoid this