### PR TITLE
Generic main handler

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -26,6 +26,8 @@ type ContextNoBody = ContextWithBody[any]
 type ContextWithBody[B any] interface {
 	context.Context
 
+	ValidableCtx
+
 	// Body returns the body of the request.
 	// If (*B) implements [InTransformer], it will be transformed after deserialization.
 	// It caches the result, so it can be called multiple times.
@@ -99,22 +101,22 @@ type ContextWithBody[B any] interface {
 	//   	return c.Redirect(301, "/recipes-list")
 	//   })
 	Redirect(code int, url string) (any, error)
+
+	Serialize(data any) error // Serialize serializes the given data to the response. It uses the Content-Type header to determine the serialization format.
+	SerializeError(err error) // SerializeError serializes the given error to the response. It uses the Content-Type header to determine the serialization format.
 }
 
 // NewNetHTTPContext returns a new context. It is used internally by Fuego. You probably want to use Ctx[B] instead.
-func NewNetHTTPContext[B any](w http.ResponseWriter, r *http.Request, options readOptions) ContextWithBody[B] {
+func NewNetHTTPContext[B any](route BaseRoute, w http.ResponseWriter, r *http.Request, options readOptions) *netHttpContext[B] {
 	c := &netHttpContext[B]{
 		CommonContext: internal.CommonContext[B]{
 			CommonCtx:     r.Context(),
 			UrlValues:     r.URL.Query(),
-			OpenAPIParams: make(map[string]OpenAPIParam),
+			OpenAPIParams: route.Params,
 		},
-		Res: w,
-		Req: r,
-		readOptions: readOptions{
-			DisallowUnknownFields: options.DisallowUnknownFields,
-			MaxBodySize:           options.MaxBodySize,
-		},
+		Req:         r,
+		Res:         w,
+		readOptions: options,
 	}
 
 	return c
@@ -134,7 +136,9 @@ type netHttpContext[Body any] struct {
 	fs        fs.FS
 	templates *template.Template
 
-	readOptions readOptions
+	readOptions    readOptions
+	serializer     Sender
+	serializeError ErrorSender
 }
 
 var (
@@ -256,6 +260,23 @@ func (c *netHttpContext[B]) Body() (B, error) {
 	body, err := body[B](*c)
 	c.body = &body
 	return body, err
+}
+
+// Serialize serializes the given data to the response. It uses the Content-Type header to determine the serialization format.
+func (c netHttpContext[B]) Serialize(data any) error {
+	if c.serializer == nil {
+		return Send(c.Res, c.Req, data)
+	}
+	return c.serializer(c.Res, c.Req, data)
+}
+
+// SerializeError serializes the given error to the response. It uses the Content-Type header to determine the serialization format.
+func (c netHttpContext[B]) SerializeError(err error) {
+	if c.serializeError == nil {
+		SendError(c.Res, c.Req, err)
+		return
+	}
+	c.serializeError(c.Res, c.Req, err)
 }
 
 func body[B any](c netHttpContext[B]) (B, error) {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -46,7 +46,7 @@ func TestContext_QueryParam(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://example.com/foo/123?id=456&other=hello&boo=true&name=jhon&name=doe", nil)
 	w := httptest.NewRecorder()
 
-	c := NewNetHTTPContext[any](w, r, readOptions{})
+	c := NewNetHTTPContext[any](BaseRoute{}, w, r, readOptions{})
 
 	t.Run("string", func(t *testing.T) {
 		param := c.QueryParam("other")
@@ -124,7 +124,7 @@ func TestContext_QueryParams(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://example.com/foo/123?id=456&other=hello", nil)
 	w := httptest.NewRecorder()
 
-	c := NewNetHTTPContext[any](w, r, readOptions{})
+	c := NewNetHTTPContext[any](BaseRoute{}, w, r, readOptions{})
 
 	params := c.QueryParams()
 	require.NotEmpty(t, params)
@@ -168,7 +168,7 @@ func TestContext_Body(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "http://example.com/foo", a)
 
-		c := NewNetHTTPContext[testStruct](w, r, readOptions{})
+		c := NewNetHTTPContext[testStruct](BaseRoute{}, w, r, readOptions{})
 
 		body, err := c.Body()
 		require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestContext_Body(t *testing.T) {
 		r := httptest.NewRequest("GET", "http://example.com/foo", a)
 		r.Header.Add("Content-Type", "application/json")
 
-		c := NewNetHTTPContext[testStruct](w, r, readOptions{})
+		c := NewNetHTTPContext[testStruct](BaseRoute{}, w, r, readOptions{})
 
 		body, err := c.Body()
 		require.NoError(t, err)
@@ -199,7 +199,7 @@ func TestContext_Body(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "http://example.com/foo", a)
 
-		c := NewNetHTTPContext[testStruct](w, r, readOptions{})
+		c := NewNetHTTPContext[testStruct](BaseRoute{}, w, r, readOptions{})
 
 		body, err := c.Body()
 		require.NoError(t, err)
@@ -220,6 +220,7 @@ func TestContext_Body(t *testing.T) {
 
 		reqBody := strings.NewReader(`{"name":"John","age":30}`)
 		c := NewNetHTTPContext[testStruct](
+			BaseRoute{},
 			httptest.NewRecorder(),
 			httptest.NewRequest("GET", "http://example.com/foo", reqBody),
 			readOptions{})
@@ -238,6 +239,7 @@ func TestContext_Body(t *testing.T) {
 
 		reqBody := strings.NewReader(`{"name":"VeryLongName","age":12}`)
 		c := NewNetHTTPContext[testStruct](
+			BaseRoute{},
 			httptest.NewRecorder(),
 			httptest.NewRequest("GET", "http://example.com/foo", reqBody),
 			readOptions{})
@@ -251,6 +253,7 @@ func TestContext_Body(t *testing.T) {
 	t.Run("can transform JSON body with custom method", func(t *testing.T) {
 		reqBody := strings.NewReader(`{"name":"John","age":30}`)
 		c := NewNetHTTPContext[testStructInTransformer](
+			BaseRoute{},
 			httptest.NewRecorder(),
 			httptest.NewRequest("GET", "http://example.com/foo", reqBody),
 			readOptions{})
@@ -264,7 +267,7 @@ func TestContext_Body(t *testing.T) {
 	t.Run("can transform JSON body with custom method returning error", func(t *testing.T) {
 		reqBody := strings.NewReader(`{"name":"John","age":30}`)
 		c := NewNetHTTPContext[testStructInTransformerWithError](
-			httptest.NewRecorder(),
+			BaseRoute{}, httptest.NewRecorder(),
 			httptest.NewRequest("GET", "http://example.com/foo", reqBody),
 			readOptions{})
 
@@ -283,7 +286,7 @@ func TestContext_Body(t *testing.T) {
 		r := httptest.NewRequest("GET", "http://example.com/foo", a)
 		r.Header.Add("Content-Type", "application/octet-stream")
 
-		c := NewNetHTTPContext[[]byte](w, r, readOptions{})
+		c := NewNetHTTPContext[[]byte](BaseRoute{}, w, r, readOptions{})
 		body, err := c.Body()
 		require.NoError(t, err)
 		require.Equal(t, []byte(`image`), body)
@@ -298,7 +301,7 @@ func TestContext_Body(t *testing.T) {
 		r := httptest.NewRequest("GET", "http://example.com/foo", a)
 		r.Header.Add("Content-Type", "application/octet-stream")
 
-		c := NewNetHTTPContext[*struct{}](w, r, readOptions{})
+		c := NewNetHTTPContext[*struct{}](BaseRoute{}, w, r, readOptions{})
 		body, err := c.Body()
 		require.Error(t, err)
 		require.ErrorContains(t, err, "use []byte as the body type")
@@ -317,7 +320,7 @@ func TestContext_Body(t *testing.T) {
 		r := httptest.NewRequest("GET", "http://example.com/foo", a)
 		r.Header.Add("Content-Type", "application/xml")
 
-		c := NewNetHTTPContext[testStruct](w, r, readOptions{})
+		c := NewNetHTTPContext[testStruct](BaseRoute{}, w, r, readOptions{})
 
 		body, err := c.Body()
 		require.NoError(t, err)
@@ -335,7 +338,7 @@ age: 30
 		r := httptest.NewRequest("GET", "http://example.com/foo", a)
 		r.Header.Add("Content-Type", "application/x-yaml")
 
-		c := NewNetHTTPContext[testStruct](w, r, readOptions{})
+		c := NewNetHTTPContext[testStruct](BaseRoute{}, w, r, readOptions{})
 
 		body, err := c.Body()
 		require.NoError(t, err)
@@ -346,7 +349,7 @@ age: 30
 	t.Run("unparsable because restricted to 1 byte", func(t *testing.T) {
 		reqBody := strings.NewReader(`{"name":"John","age":30}`)
 		c := NewNetHTTPContext[testStructInTransformerWithError](
-			httptest.NewRecorder(),
+			BaseRoute{}, httptest.NewRecorder(),
 			httptest.NewRequest("GET", "http://example.com/foo", reqBody),
 			readOptions{
 				MaxBodySize: 1,
@@ -367,7 +370,7 @@ age: 30
 		r := httptest.NewRequest("GET", "http://example.com/foo", a)
 		r.Header.Set("Content-Type", "text/plain")
 
-		c := NewNetHTTPContext[string](w, r, readOptions{})
+		c := NewNetHTTPContext[string](BaseRoute{}, w, r, readOptions{})
 
 		_, err := c.Body()
 		require.NoError(t, err)
@@ -386,7 +389,7 @@ func FuzzContext_Body(f *testing.F) {
 		r := httptest.NewRequest("GET", "http://example.com/foo", a)
 		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-		c := NewNetHTTPContext[testStruct](w, r, readOptions{})
+		c := NewNetHTTPContext[testStruct](BaseRoute{}, w, r, readOptions{})
 
 		_, err := c.Body()
 		require.NoError(t, err)
@@ -398,7 +401,7 @@ func BenchmarkContext_Body(b *testing.B) {
 		for i := range b.N {
 			reqBody := strings.NewReader(`{"name":"John","age":30}`)
 			c := NewNetHTTPContext[testStruct](
-				httptest.NewRecorder(),
+				BaseRoute{}, httptest.NewRecorder(),
 				httptest.NewRequest("GET", "http://example.com/foo", reqBody),
 				readOptions{})
 			_, err := c.Body()
@@ -414,7 +417,7 @@ func BenchmarkContext_Body(b *testing.B) {
 	b.Run("valid JSON body cache", func(b *testing.B) {
 		reqBody := strings.NewReader(`{"name":"John","age":30}`)
 		c := NewNetHTTPContext[testStruct](
-			httptest.NewRecorder(),
+			BaseRoute{}, httptest.NewRecorder(),
 			httptest.NewRequest("GET", "http://example.com/foo", reqBody),
 			readOptions{})
 		for i := range b.N {
@@ -429,7 +432,7 @@ func BenchmarkContext_Body(b *testing.B) {
 		for range b.N {
 			reqBody := strings.NewReader(`{"name":"John","age":30}`)
 			c := NewNetHTTPContext[testStruct](
-				httptest.NewRecorder(),
+				BaseRoute{}, httptest.NewRecorder(),
 				httptest.NewRequest("GET", "http://example.com/foo", reqBody),
 				readOptions{})
 			_, err := c.Body()
@@ -443,7 +446,7 @@ func BenchmarkContext_Body(b *testing.B) {
 		for range b.N {
 			reqBody := strings.NewReader(`{"name":"John","age":30}`)
 			c := NewNetHTTPContext[testStruct](
-				httptest.NewRecorder(),
+				BaseRoute{}, httptest.NewRecorder(),
 				httptest.NewRequest("GET", "http://example.com/foo", reqBody),
 				readOptions{})
 			_, err := c.Body()
@@ -463,7 +466,7 @@ func TestContext_MustBody(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "http://example.com/foo", a)
 
-		c := NewNetHTTPContext[testStruct](w, r, readOptions{})
+		c := NewNetHTTPContext[testStruct](BaseRoute{}, w, r, readOptions{})
 
 		body := c.MustBody()
 		require.Equal(t, "John", body.Name)
@@ -478,7 +481,7 @@ func TestContext_MustBody(t *testing.T) {
 
 		reqBody := strings.NewReader(`{"name":"VeryLongName","age":12}`)
 		c := NewNetHTTPContext[testStruct](
-			httptest.NewRecorder(),
+			BaseRoute{}, httptest.NewRecorder(),
 			httptest.NewRequest("GET", "http://example.com/foo", reqBody),
 			readOptions{})
 
@@ -492,7 +495,7 @@ func TestMainLang(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
 	r.Header.Set("Accept-Language", "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5")
 
-	c := NewNetHTTPContext[any](httptest.NewRecorder(), r, readOptions{})
+	c := NewNetHTTPContext[any](BaseRoute{}, httptest.NewRecorder(), r, readOptions{})
 	require.Equal(t, c.MainLang(), "fr")
 	require.Equal(t, c.MainLocale(), "fr-CH")
 }

--- a/internal/common_context.go
+++ b/internal/common_context.go
@@ -38,6 +38,9 @@ type CommonContext[B any] struct {
 
 	UrlValues     url.Values
 	OpenAPIParams map[string]OpenAPIParam // list of expected query parameters (declared in the OpenAPI spec)
+
+	// default status code for the response
+	DefaultStatusCode int
 }
 
 type ParamType string // Query, Header, Cookie

--- a/serve_test.go
+++ b/serve_test.go
@@ -349,7 +349,7 @@ func TestIni(t *testing.T) {
 	t.Run("can initialize ContextNoBody", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ctx/error-in-rendering", nil)
 		w := httptest.NewRecorder()
-		ctx := NewNetHTTPContext[any](w, req, readOptions{})
+		ctx := NewNetHTTPContext[any](BaseRoute{}, w, req, readOptions{})
 
 		require.NotNil(t, ctx)
 		require.NotNil(t, ctx.Request())
@@ -359,7 +359,7 @@ func TestIni(t *testing.T) {
 	t.Run("can initialize ContextNoBody", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ctx/error-in-rendering", nil)
 		w := httptest.NewRecorder()
-		ctx := NewNetHTTPContext[any](w, req, readOptions{})
+		ctx := NewNetHTTPContext[any](BaseRoute{}, w, req, readOptions{})
 
 		require.NotNil(t, ctx)
 		require.NotNil(t, ctx.Request())
@@ -369,7 +369,7 @@ func TestIni(t *testing.T) {
 	t.Run("can initialize ContextWithBody[string]", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ctx/error-in-rendering", nil)
 		w := httptest.NewRecorder()
-		ctx := NewNetHTTPContext[any](w, req, readOptions{})
+		ctx := NewNetHTTPContext[any](BaseRoute{}, w, req, readOptions{})
 
 		require.NotNil(t, ctx)
 		require.NotNil(t, ctx.Request())
@@ -379,7 +379,7 @@ func TestIni(t *testing.T) {
 	t.Run("can initialize ContextWithBody[struct]", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ctx/error-in-rendering", nil)
 		w := httptest.NewRecorder()
-		ctx := NewNetHTTPContext[any](w, req, readOptions{})
+		ctx := NewNetHTTPContext[any](BaseRoute{}, w, req, readOptions{})
 
 		require.NotNil(t, ctx)
 		require.NotNil(t, ctx.Request())


### PR DESCRIPTION
_Please look at the Pull Request in your IDE, the default Github diff is ugly._

This PR is made to make the previous Fuego `net/http` flow with validation, error handling... generic. It only uses Fuego's abstractions (the new `Engine`, `ContextWithBody`, and the good old fuego controller).

I will then move `flow` to internal and reuse it in the gin extension.