### PR TITLE
feat: Server.WithEngine config

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -30,7 +30,13 @@ type Engine struct {
 	acceptedContentTypes []string
 }
 
-type EngineOpenAPIConfig struct {
+var defaultOpenAPIConfig = OpenAPIConfig{
+	JSONFilePath: "doc/openapi.json",
+}
+
+type OpenAPIConfig struct {
+	// If true, the server will not serve or generate and OpenAPI resources
+	Disabled bool
 	// If true, the engine will not print messages
 	DisableMessages bool
 	// If true, the engine will not save the OpenAPI JSON spec locally
@@ -43,36 +49,13 @@ type EngineOpenAPIConfig struct {
 
 func WithOpenAPIConfig(config OpenAPIConfig) func(*Engine) {
 	return func(e *Engine) {
-		if config.JsonURL != "" {
-			e.OpenAPIConfig.JsonURL = config.JsonURL
-		}
-
-		if config.SwaggerURL != "" {
-			e.OpenAPIConfig.SwaggerURL = config.SwaggerURL
-		}
-
 		if config.JSONFilePath != "" {
 			e.OpenAPIConfig.JSONFilePath = config.JSONFilePath
 		}
 
-		if config.UIHandler != nil {
-			e.OpenAPIConfig.UIHandler = config.UIHandler
-		}
-
-		e.OpenAPIConfig.DisableSwagger = config.DisableSwagger
-		e.OpenAPIConfig.DisableSwaggerUI = config.DisableSwaggerUI
+		e.OpenAPIConfig.Disabled = config.Disabled
 		e.OpenAPIConfig.DisableLocalSave = config.DisableLocalSave
 		e.OpenAPIConfig.PrettyFormatJSON = config.PrettyFormatJSON
-
-		if !validateJsonSpecUrl(e.OpenAPIConfig.JsonURL) {
-			slog.Error("Error serving openapi json spec. Value of 's.OpenAPIConfig.JsonSpecUrl' option is not valid", "url", e.OpenAPIConfig.JsonURL)
-			return
-		}
-
-		if !validateSwaggerUrl(e.OpenAPIConfig.SwaggerURL) {
-			slog.Error("Error serving swagger ui. Value of 's.OpenAPIConfig.SwaggerUrl' option is not valid", "url", e.OpenAPIConfig.SwaggerURL)
-			return
-		}
 	}
 }
 

--- a/engine.go
+++ b/engine.go
@@ -1,16 +1,139 @@
 package fuego
 
-func NewEngine() *Engine {
-	return &Engine{
-		OpenAPI:      NewOpenAPI(),
-		ErrorHandler: ErrorHandler,
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+func NewEngine(config ...OpenAPIConfig) *Engine {
+	if len(config) > 1 {
+		panic("config should not be more than one")
 	}
+	engine := &Engine{
+		OpenAPI:       NewOpenAPI(),
+		OpenAPIConfig: defaultOpenAPIConfig,
+		ErrorHandler:  ErrorHandler,
+	}
+	if len(config) > 0 {
+		engine.setOpenAPIConfig(config[0])
+	}
+	return engine
 }
 
 // The Engine is the main struct of the framework.
 type Engine struct {
-	OpenAPI      *OpenAPI
-	ErrorHandler func(error) error
+	OpenAPI       *OpenAPI
+	ErrorHandler  func(error) error
+	OpenAPIConfig OpenAPIConfig
 
 	acceptedContentTypes []string
+}
+
+type EngineOpenAPIConfig struct {
+	// If true, the engine will not print messages
+	DisableMessages bool
+	// If true, the engine will not save the OpenAPI JSON spec locally
+	DisableLocalSave bool
+	// Local path to save the OpenAPI JSON spec
+	JsonFilePath string
+	// Pretty prints the OpenAPI spec with proper JSON indentation
+	PrettyFormatJson bool
+}
+
+// OutputOpenAPISpec takes the OpenAPI spec and outputs it to a JSON file
+func (e *Engine) OutputOpenAPISpec() []byte {
+	e.OpenAPI.computeTags()
+
+	// Validate
+	err := e.OpenAPI.Description().Validate(context.Background())
+	if err != nil {
+		slog.Error("Error validating spec", "error", err)
+	}
+
+	// Marshal spec to JSON
+	jsonSpec, err := e.marshalSpec()
+	if err != nil {
+		slog.Error("Error marshaling spec to JSON", "error", err)
+	}
+
+	if !e.OpenAPIConfig.DisableLocalSave {
+		err := e.saveOpenAPIToFile(e.OpenAPIConfig.JsonFilePath, jsonSpec)
+		if err != nil {
+			slog.Error("Error saving spec to local path", "error", err, "path", e.OpenAPIConfig.JsonFilePath)
+		}
+	}
+	return jsonSpec
+}
+
+func (e *Engine) saveOpenAPIToFile(jsonSpecLocalPath string, jsonSpec []byte) error {
+	jsonFolder := filepath.Dir(jsonSpecLocalPath)
+
+	err := os.MkdirAll(jsonFolder, 0o750)
+	if err != nil {
+		return errors.New("error creating docs directory")
+	}
+
+	f, err := os.Create(jsonSpecLocalPath) // #nosec G304 (file path provided by developer, not by user)
+	if err != nil {
+		return errors.New("error creating file")
+	}
+	defer f.Close()
+
+	_, err = f.Write(jsonSpec)
+	if err != nil {
+		return errors.New("error writing file ")
+	}
+
+	e.printOpenAPIMessage("JSON file: " + jsonSpecLocalPath)
+	return nil
+}
+
+func (s *Engine) marshalSpec() ([]byte, error) {
+	if s.OpenAPIConfig.PrettyFormatJson {
+		return json.MarshalIndent(s.OpenAPI.Description(), "", "	")
+	}
+	return json.Marshal(s.OpenAPI.Description())
+}
+
+func (e *Engine) setOpenAPIConfig(config OpenAPIConfig) {
+	if config.JsonUrl != "" {
+		e.OpenAPIConfig.JsonUrl = config.JsonUrl
+	}
+
+	if config.SwaggerUrl != "" {
+		e.OpenAPIConfig.SwaggerUrl = config.SwaggerUrl
+	}
+
+	if config.JsonFilePath != "" {
+		e.OpenAPIConfig.JsonFilePath = config.JsonFilePath
+	}
+
+	if config.UIHandler != nil {
+		e.OpenAPIConfig.UIHandler = config.UIHandler
+	}
+
+	e.OpenAPIConfig.DisableSwagger = config.DisableSwagger
+	e.OpenAPIConfig.DisableSwaggerUI = config.DisableSwaggerUI
+	e.OpenAPIConfig.DisableLocalSave = config.DisableLocalSave
+	e.OpenAPIConfig.PrettyFormatJson = config.PrettyFormatJson
+
+	if !validateJsonSpecUrl(e.OpenAPIConfig.JsonUrl) {
+		slog.Error("Error serving openapi json spec. Value of 's.OpenAPIConfig.JsonSpecUrl' option is not valid", "url", e.OpenAPIConfig.JsonUrl)
+		return
+	}
+
+	if !validateSwaggerUrl(e.OpenAPIConfig.SwaggerUrl) {
+		slog.Error("Error serving swagger ui. Value of 's.OpenAPIConfig.SwaggerUrl' option is not valid", "url", e.OpenAPIConfig.SwaggerUrl)
+		return
+	}
+}
+
+func (e *Engine) printOpenAPIMessage(msg string) {
+	if !e.OpenAPIConfig.DisableMessages {
+		slog.Info(msg)
+	}
 }

--- a/engine.go
+++ b/engine.go
@@ -36,23 +36,23 @@ type EngineOpenAPIConfig struct {
 	// If true, the engine will not save the OpenAPI JSON spec locally
 	DisableLocalSave bool
 	// Local path to save the OpenAPI JSON spec
-	JsonFilePath string
+	JSONFilePath string
 	// Pretty prints the OpenAPI spec with proper JSON indentation
-	PrettyFormatJson bool
+	PrettyFormatJSON bool
 }
 
 func WithOpenAPIConfig(config OpenAPIConfig) func(*Engine) {
 	return func(e *Engine) {
-		if config.JsonUrl != "" {
-			e.OpenAPIConfig.JsonUrl = config.JsonUrl
+		if config.JsonURL != "" {
+			e.OpenAPIConfig.JsonURL = config.JsonURL
 		}
 
-		if config.SwaggerUrl != "" {
-			e.OpenAPIConfig.SwaggerUrl = config.SwaggerUrl
+		if config.SwaggerURL != "" {
+			e.OpenAPIConfig.SwaggerURL = config.SwaggerURL
 		}
 
-		if config.JsonFilePath != "" {
-			e.OpenAPIConfig.JsonFilePath = config.JsonFilePath
+		if config.JSONFilePath != "" {
+			e.OpenAPIConfig.JSONFilePath = config.JSONFilePath
 		}
 
 		if config.UIHandler != nil {
@@ -62,15 +62,15 @@ func WithOpenAPIConfig(config OpenAPIConfig) func(*Engine) {
 		e.OpenAPIConfig.DisableSwagger = config.DisableSwagger
 		e.OpenAPIConfig.DisableSwaggerUI = config.DisableSwaggerUI
 		e.OpenAPIConfig.DisableLocalSave = config.DisableLocalSave
-		e.OpenAPIConfig.PrettyFormatJson = config.PrettyFormatJson
+		e.OpenAPIConfig.PrettyFormatJSON = config.PrettyFormatJSON
 
-		if !validateJsonSpecUrl(e.OpenAPIConfig.JsonUrl) {
-			slog.Error("Error serving openapi json spec. Value of 's.OpenAPIConfig.JsonSpecUrl' option is not valid", "url", e.OpenAPIConfig.JsonUrl)
+		if !validateJsonSpecUrl(e.OpenAPIConfig.JsonURL) {
+			slog.Error("Error serving openapi json spec. Value of 's.OpenAPIConfig.JsonSpecUrl' option is not valid", "url", e.OpenAPIConfig.JsonURL)
 			return
 		}
 
-		if !validateSwaggerUrl(e.OpenAPIConfig.SwaggerUrl) {
-			slog.Error("Error serving swagger ui. Value of 's.OpenAPIConfig.SwaggerUrl' option is not valid", "url", e.OpenAPIConfig.SwaggerUrl)
+		if !validateSwaggerUrl(e.OpenAPIConfig.SwaggerURL) {
+			slog.Error("Error serving swagger ui. Value of 's.OpenAPIConfig.SwaggerUrl' option is not valid", "url", e.OpenAPIConfig.SwaggerURL)
 			return
 		}
 	}
@@ -93,9 +93,9 @@ func (e *Engine) OutputOpenAPISpec() []byte {
 	}
 
 	if !e.OpenAPIConfig.DisableLocalSave {
-		err := e.saveOpenAPIToFile(e.OpenAPIConfig.JsonFilePath, jsonSpec)
+		err := e.saveOpenAPIToFile(e.OpenAPIConfig.JSONFilePath, jsonSpec)
 		if err != nil {
-			slog.Error("Error saving spec to local path", "error", err, "path", e.OpenAPIConfig.JsonFilePath)
+			slog.Error("Error saving spec to local path", "error", err, "path", e.OpenAPIConfig.JSONFilePath)
 		}
 	}
 	return jsonSpec
@@ -125,7 +125,7 @@ func (e *Engine) saveOpenAPIToFile(jsonSpecLocalPath string, jsonSpec []byte) er
 }
 
 func (s *Engine) marshalSpec() ([]byte, error) {
-	if s.OpenAPIConfig.PrettyFormatJson {
+	if s.OpenAPIConfig.PrettyFormatJSON {
 		return json.MarshalIndent(s.OpenAPI.Description(), "", "	")
 	}
 	return json.Marshal(s.OpenAPI.Description())

--- a/examples/generate-opengraph-image/main.go
+++ b/examples/generate-opengraph-image/main.go
@@ -21,11 +21,13 @@ var optionReturnsPNG = func(br *fuego.BaseRoute) {
 
 func main() {
 	s := fuego.NewServer(
-		fuego.WithOpenAPIConfig(fuego.OpenAPIConfig{
-			EngineOpenAPIConfig: fuego.EngineOpenAPIConfig{
-				PrettyFormatJson: true,
-			},
-		}),
+		fuego.WithEngineOptions(
+			fuego.WithOpenAPIConfig(fuego.OpenAPIConfig{
+				EngineOpenAPIConfig: fuego.EngineOpenAPIConfig{
+					PrettyFormatJson: true,
+				},
+			}),
+		),
 	)
 
 	fuego.GetStd(s, "/{title}", controller.OpenGraphHandler,

--- a/examples/generate-opengraph-image/main.go
+++ b/examples/generate-opengraph-image/main.go
@@ -22,7 +22,9 @@ var optionReturnsPNG = func(br *fuego.BaseRoute) {
 func main() {
 	s := fuego.NewServer(
 		fuego.WithOpenAPIConfig(fuego.OpenAPIConfig{
-			PrettyFormatJson: true,
+			EngineOpenAPIConfig: fuego.EngineOpenAPIConfig{
+				PrettyFormatJson: true,
+			},
 		}),
 	)
 

--- a/examples/generate-opengraph-image/main.go
+++ b/examples/generate-opengraph-image/main.go
@@ -24,7 +24,7 @@ func main() {
 		fuego.WithEngineOptions(
 			fuego.WithOpenAPIConfig(fuego.OpenAPIConfig{
 				EngineOpenAPIConfig: fuego.EngineOpenAPIConfig{
-					PrettyFormatJson: true,
+					PrettyFormatJSON: true,
 				},
 			}),
 		),

--- a/examples/generate-opengraph-image/main.go
+++ b/examples/generate-opengraph-image/main.go
@@ -21,13 +21,11 @@ var optionReturnsPNG = func(br *fuego.BaseRoute) {
 
 func main() {
 	s := fuego.NewServer(
-		fuego.WithEngineOptions(
-			fuego.WithOpenAPIConfig(fuego.OpenAPIConfig{
-				EngineOpenAPIConfig: fuego.EngineOpenAPIConfig{
-					PrettyFormatJSON: true,
-				},
-			}),
-		),
+		fuego.WithEngine(fuego.NewEngine(fuego.WithOpenAPIConfig(
+			fuego.OpenAPIConfig{
+				PrettyFormatJSON: true,
+			},
+		))),
 	)
 
 	fuego.GetStd(s, "/{title}", controller.OpenGraphHandler,

--- a/examples/petstore/lib/server_test.go
+++ b/examples/petstore/lib/server_test.go
@@ -14,14 +14,12 @@ import (
 func TestPetstoreOpenAPIGeneration(t *testing.T) {
 	server := NewPetStoreServer(
 		fuego.WithoutStartupMessages(),
-		fuego.WithEngineOptions(
-			fuego.WithOpenAPIConfig(fuego.OpenAPIConfig{
-				EngineOpenAPIConfig: fuego.EngineOpenAPIConfig{
-					JSONFilePath:     "testdata/doc/openapi.json",
-					PrettyFormatJSON: true,
-				},
-			}),
-		),
+		fuego.WithEngine(fuego.NewEngine(fuego.WithOpenAPIConfig(
+			fuego.OpenAPIConfig{
+				JSONFilePath:     "testdata/doc/openapi.json",
+				PrettyFormatJSON: true,
+			},
+		))),
 	)
 
 	server.OutputOpenAPISpec()

--- a/examples/petstore/lib/server_test.go
+++ b/examples/petstore/lib/server_test.go
@@ -15,8 +15,10 @@ func TestPetstoreOpenAPIGeneration(t *testing.T) {
 	server := NewPetStoreServer(
 		fuego.WithoutStartupMessages(),
 		fuego.WithOpenAPIConfig(fuego.OpenAPIConfig{
-			JsonFilePath:     "testdata/doc/openapi.json",
-			PrettyFormatJson: true,
+			EngineOpenAPIConfig: fuego.EngineOpenAPIConfig{
+				JsonFilePath:     "testdata/doc/openapi.json",
+				PrettyFormatJson: true,
+			},
 		}),
 	)
 

--- a/examples/petstore/lib/server_test.go
+++ b/examples/petstore/lib/server_test.go
@@ -14,12 +14,14 @@ import (
 func TestPetstoreOpenAPIGeneration(t *testing.T) {
 	server := NewPetStoreServer(
 		fuego.WithoutStartupMessages(),
-		fuego.WithOpenAPIConfig(fuego.OpenAPIConfig{
-			EngineOpenAPIConfig: fuego.EngineOpenAPIConfig{
-				JsonFilePath:     "testdata/doc/openapi.json",
-				PrettyFormatJson: true,
-			},
-		}),
+		fuego.WithEngineOptions(
+			fuego.WithOpenAPIConfig(fuego.OpenAPIConfig{
+				EngineOpenAPIConfig: fuego.EngineOpenAPIConfig{
+					JsonFilePath:     "testdata/doc/openapi.json",
+					PrettyFormatJson: true,
+				},
+			}),
+		),
 	)
 
 	server.OutputOpenAPISpec()

--- a/examples/petstore/lib/server_test.go
+++ b/examples/petstore/lib/server_test.go
@@ -17,8 +17,8 @@ func TestPetstoreOpenAPIGeneration(t *testing.T) {
 		fuego.WithEngineOptions(
 			fuego.WithOpenAPIConfig(fuego.OpenAPIConfig{
 				EngineOpenAPIConfig: fuego.EngineOpenAPIConfig{
-					JsonFilePath:     "testdata/doc/openapi.json",
-					PrettyFormatJson: true,
+					JSONFilePath:     "testdata/doc/openapi.json",
+					PrettyFormatJSON: true,
 				},
 			}),
 		),

--- a/openapi.go
+++ b/openapi.go
@@ -1,7 +1,6 @@
 package fuego
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -112,29 +111,8 @@ func (s *Server) OutputOpenAPISpec() openapi3.T {
 		Description: "local server",
 	})
 
-	s.OpenAPI.computeTags()
-
-	// Validate
-	err := s.OpenAPI.Description().Validate(context.Background())
-	if err != nil {
-		slog.Error("Error validating spec", "error", err)
-	}
-
-	// Marshal spec to JSON
-	jsonSpec, err := s.marshalSpec()
-	if err != nil {
-		slog.Error("Error marshaling spec to JSON", "error", err)
-	}
-
 	if !s.OpenAPIConfig.DisableSwagger {
-		s.registerOpenAPIRoutes(jsonSpec)
-	}
-
-	if !s.OpenAPIConfig.DisableLocalSave {
-		err := s.saveOpenAPIToFile(s.OpenAPIConfig.JsonFilePath, jsonSpec)
-		if err != nil {
-			slog.Error("Error saving spec to local path", "error", err, "path", s.OpenAPIConfig.JsonFilePath)
-		}
+		s.registerOpenAPIRoutes(s.Engine.OutputOpenAPISpec())
 	}
 
 	return *s.OpenAPI.Description()
@@ -186,12 +164,6 @@ func (s *Server) registerOpenAPIRoutes(jsonSpec []byte) {
 			},
 		}, s.OpenAPIConfig.UIHandler(s.OpenAPIConfig.JsonUrl))
 		s.printOpenAPIMessage(fmt.Sprintf("OpenAPI UI: %s%s/index.html", s.url(), s.OpenAPIConfig.SwaggerUrl))
-	}
-}
-
-func (s *Server) printOpenAPIMessage(msg string) {
-	if !s.disableStartupMessages {
-		slog.Info(msg)
 	}
 }
 

--- a/openapi.go
+++ b/openapi.go
@@ -107,7 +107,7 @@ func (s *Server) OutputOpenAPISpec() openapi3.T {
 		Description: "local server",
 	})
 
-	if !s.OpenAPIConfig.DisableSwagger {
+	if !s.Engine.OpenAPIConfig.Disabled {
 		s.registerOpenAPIRoutes(s.Engine.OutputOpenAPISpec())
 	}
 
@@ -116,24 +116,24 @@ func (s *Server) OutputOpenAPISpec() openapi3.T {
 
 // Registers the routes to serve the OpenAPI spec and Swagger UI.
 func (s *Server) registerOpenAPIRoutes(jsonSpec []byte) {
-	GetStd(s, s.OpenAPIConfig.JsonURL, func(w http.ResponseWriter, r *http.Request) {
+	GetStd(s, s.OpenAPIServerConfig.JsonURL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(jsonSpec)
 	})
-	s.printOpenAPIMessage(fmt.Sprintf("JSON spec: %s%s", s.url(), s.OpenAPIConfig.JsonURL))
+	s.printOpenAPIMessage(fmt.Sprintf("JSON spec: %s%s", s.url(), s.OpenAPIServerConfig.JsonURL))
 
-	if !s.OpenAPIConfig.DisableSwaggerUI {
+	if !s.OpenAPIServerConfig.DisableSwaggerUI {
 		Registers(s.Engine, netHttpRouteRegisterer[any, any]{
 			s: s,
 			route: Route[any, any]{
 				BaseRoute: BaseRoute{
 					Method: http.MethodGet,
-					Path:   s.OpenAPIConfig.SwaggerURL + "/",
+					Path:   s.OpenAPIServerConfig.SwaggerURL + "/",
 				},
 			},
-			controller: s.OpenAPIConfig.UIHandler(s.OpenAPIConfig.JsonURL),
+			controller: s.OpenAPIServerConfig.UIHandler(s.OpenAPIServerConfig.JsonURL),
 		})
-		s.printOpenAPIMessage(fmt.Sprintf("OpenAPI UI: %s%s/index.html", s.url(), s.OpenAPIConfig.SwaggerURL))
+		s.printOpenAPIMessage(fmt.Sprintf("OpenAPI UI: %s%s/index.html", s.url(), s.OpenAPIServerConfig.SwaggerURL))
 	}
 }
 

--- a/openapi.go
+++ b/openapi.go
@@ -150,11 +150,11 @@ func (s *Server) saveOpenAPIToFile(jsonSpecLocalPath string, jsonSpec []byte) er
 
 // Registers the routes to serve the OpenAPI spec and Swagger UI.
 func (s *Server) registerOpenAPIRoutes(jsonSpec []byte) {
-	GetStd(s, s.OpenAPIConfig.JsonUrl, func(w http.ResponseWriter, r *http.Request) {
+	GetStd(s, s.OpenAPIConfig.JsonURL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(jsonSpec)
 	})
-	s.printOpenAPIMessage(fmt.Sprintf("JSON spec: %s%s", s.url(), s.OpenAPIConfig.JsonUrl))
+	s.printOpenAPIMessage(fmt.Sprintf("JSON spec: %s%s", s.url(), s.OpenAPIConfig.JsonURL))
 
 	if !s.OpenAPIConfig.DisableSwaggerUI {
 		Registers(s.Engine, netHttpRouteRegisterer[any, any]{
@@ -162,12 +162,12 @@ func (s *Server) registerOpenAPIRoutes(jsonSpec []byte) {
 			route: Route[any, any]{
 				BaseRoute: BaseRoute{
 					Method: http.MethodGet,
-					Path:   s.OpenAPIConfig.SwaggerUrl + "/",
+					Path:   s.OpenAPIConfig.SwaggerURL + "/",
 				},
 			},
-			controller: s.OpenAPIConfig.UIHandler(s.OpenAPIConfig.JsonUrl),
+			controller: s.OpenAPIConfig.UIHandler(s.OpenAPIConfig.JsonURL),
 		})
-		s.printOpenAPIMessage(fmt.Sprintf("OpenAPI UI: %s%s/index.html", s.url(), s.OpenAPIConfig.SwaggerUrl))
+		s.printOpenAPIMessage(fmt.Sprintf("OpenAPI UI: %s%s/index.html", s.url(), s.OpenAPIConfig.SwaggerURL))
 	}
 }
 

--- a/openapi.go
+++ b/openapi.go
@@ -157,12 +157,16 @@ func (s *Server) registerOpenAPIRoutes(jsonSpec []byte) {
 	s.printOpenAPIMessage(fmt.Sprintf("JSON spec: %s%s", s.url(), s.OpenAPIConfig.JsonUrl))
 
 	if !s.OpenAPIConfig.DisableSwaggerUI {
-		Register(s, Route[any, any]{
-			BaseRoute: BaseRoute{
-				Method: http.MethodGet,
-				Path:   s.OpenAPIConfig.SwaggerUrl + "/",
+		Registers(s.Engine, netHttpRouteRegisterer[any, any]{
+			s: s,
+			route: Route[any, any]{
+				BaseRoute: BaseRoute{
+					Method: http.MethodGet,
+					Path:   s.OpenAPIConfig.SwaggerUrl + "/",
+				},
 			},
-		}, s.OpenAPIConfig.UIHandler(s.OpenAPIConfig.JsonUrl))
+			controller: s.OpenAPIConfig.UIHandler(s.OpenAPIConfig.JsonUrl),
+		})
 		s.printOpenAPIMessage(fmt.Sprintf("OpenAPI UI: %s%s/index.html", s.url(), s.OpenAPIConfig.SwaggerUrl))
 	}
 }

--- a/openapi.go
+++ b/openapi.go
@@ -1,13 +1,9 @@
 package fuego
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
-	"path/filepath"
 	"reflect"
 	"regexp"
 	"slices"
@@ -116,36 +112,6 @@ func (s *Server) OutputOpenAPISpec() openapi3.T {
 	}
 
 	return *s.OpenAPI.Description()
-}
-
-func (s *Server) marshalSpec() ([]byte, error) {
-	if s.OpenAPIConfig.PrettyFormatJson {
-		return json.MarshalIndent(s.OpenAPI.Description(), "", "\t")
-	}
-	return json.Marshal(s.OpenAPI.Description())
-}
-
-func (s *Server) saveOpenAPIToFile(jsonSpecLocalPath string, jsonSpec []byte) error {
-	jsonFolder := filepath.Dir(jsonSpecLocalPath)
-
-	err := os.MkdirAll(jsonFolder, 0o750)
-	if err != nil {
-		return errors.New("error creating docs directory")
-	}
-
-	f, err := os.Create(jsonSpecLocalPath) // #nosec G304 (file path provided by developer, not by user)
-	if err != nil {
-		return errors.New("error creating file")
-	}
-	defer f.Close()
-
-	_, err = f.Write(jsonSpec)
-	if err != nil {
-		return errors.New("error writing file ")
-	}
-
-	s.printOpenAPIMessage("JSON file: " + jsonSpecLocalPath)
-	return nil
 }
 
 // Registers the routes to serve the OpenAPI spec and Swagger UI.

--- a/openapi_handler_test.go
+++ b/openapi_handler_test.go
@@ -23,7 +23,7 @@ func TestUIHandler(t *testing.T) {
 
 		s.OutputOpenAPISpec()
 
-		require.NotNil(t, s.OpenAPIConfig.UIHandler)
+		require.NotNil(t, s.OpenAPIServerConfig.UIHandler)
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "/swagger/index.html", nil)
@@ -37,17 +37,15 @@ func TestUIHandler(t *testing.T) {
 
 	t.Run("wrap DefaultOpenAPIHandler behind a middleware", func(t *testing.T) {
 		s := NewServer(
-			WithEngineOptions(
-				WithOpenAPIConfig(OpenAPIConfig{
-					UIHandler: func(specURL string) http.Handler {
-						return dummyMiddleware(DefaultOpenAPIHandler(specURL))
-					},
-				}),
-			),
+			WithOpenAPIServerConfig(OpenAPIServerConfig{
+				UIHandler: func(specURL string) http.Handler {
+					return dummyMiddleware(DefaultOpenAPIHandler(specURL))
+				},
+			}),
 		)
 		s.OutputOpenAPISpec()
 
-		require.NotNil(t, s.OpenAPIConfig.UIHandler)
+		require.NotNil(t, s.OpenAPIServerConfig.UIHandler)
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "/swagger/index.html", nil)
@@ -61,11 +59,9 @@ func TestUIHandler(t *testing.T) {
 
 	t.Run("disabling UI", func(t *testing.T) {
 		s := NewServer(
-			WithEngineOptions(
-				WithOpenAPIConfig(OpenAPIConfig{
-					DisableSwaggerUI: true,
-				}),
-			),
+			WithOpenAPIServerConfig(OpenAPIServerConfig{
+				DisableSwaggerUI: true,
+			}),
 		)
 
 		s.OutputOpenAPISpec()

--- a/openapi_handler_test.go
+++ b/openapi_handler_test.go
@@ -37,11 +37,13 @@ func TestUIHandler(t *testing.T) {
 
 	t.Run("wrap DefaultOpenAPIHandler behind a middleware", func(t *testing.T) {
 		s := NewServer(
-			WithOpenAPIConfig(OpenAPIConfig{
-				UIHandler: func(specURL string) http.Handler {
-					return dummyMiddleware(DefaultOpenAPIHandler(specURL))
-				},
-			}),
+			WithEngineOptions(
+				WithOpenAPIConfig(OpenAPIConfig{
+					UIHandler: func(specURL string) http.Handler {
+						return dummyMiddleware(DefaultOpenAPIHandler(specURL))
+					},
+				}),
+			),
 		)
 		s.OutputOpenAPISpec()
 
@@ -59,9 +61,11 @@ func TestUIHandler(t *testing.T) {
 
 	t.Run("disabling UI", func(t *testing.T) {
 		s := NewServer(
-			WithOpenAPIConfig(OpenAPIConfig{
-				DisableSwaggerUI: true,
-			}),
+			WithEngineOptions(
+				WithOpenAPIConfig(OpenAPIConfig{
+					DisableSwaggerUI: true,
+				}),
+			),
 		)
 
 		s.OutputOpenAPISpec()

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -247,7 +247,9 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 		s := NewServer(
 			WithOpenAPIConfig(
 				OpenAPIConfig{
-					JsonFilePath: docPath,
+					EngineOpenAPIConfig: EngineOpenAPIConfig{
+						JsonFilePath: docPath,
+					},
 				},
 			),
 		)
@@ -268,8 +270,10 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 		s := NewServer(
 			WithOpenAPIConfig(
 				OpenAPIConfig{
-					JsonFilePath:     docPath,
-					DisableLocalSave: true,
+					EngineOpenAPIConfig: EngineOpenAPIConfig{
+						JsonFilePath:     docPath,
+						DisableLocalSave: true,
+					},
 				},
 			),
 		)
@@ -288,9 +292,11 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 		s := NewServer(
 			WithOpenAPIConfig(
 				OpenAPIConfig{
-					JsonFilePath:     docPath,
-					DisableLocalSave: true,
-					DisableSwagger:   true,
+					EngineOpenAPIConfig: EngineOpenAPIConfig{
+						JsonFilePath:     docPath,
+						DisableLocalSave: true,
+					},
+					DisableSwagger: true,
 				},
 			),
 		)
@@ -310,8 +316,10 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 		s := NewServer(
 			WithOpenAPIConfig(
 				OpenAPIConfig{
-					JsonFilePath:     docPath,
-					PrettyFormatJson: true,
+					EngineOpenAPIConfig: EngineOpenAPIConfig{
+						JsonFilePath:     docPath,
+						PrettyFormatJson: true,
+					},
 				},
 			),
 		)
@@ -426,8 +434,10 @@ func TestLocalSave(t *testing.T) {
 func TestAutoGroupTags(t *testing.T) {
 	s := NewServer(
 		WithOpenAPIConfig(OpenAPIConfig{
-			DisableLocalSave: true,
-			DisableSwagger:   true,
+			EngineOpenAPIConfig: EngineOpenAPIConfig{
+				DisableLocalSave: true,
+			},
+			DisableSwagger: true,
 		}),
 	)
 	Get(s, "/a", func(ContextNoBody) (MyStruct, error) {

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -245,15 +245,13 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 	docPath := "doc/openapi.json"
 	t.Run("base", func(t *testing.T) {
 		s := NewServer(
-			WithEngineOptions(
+			WithEngine(NewEngine(
 				WithOpenAPIConfig(
 					OpenAPIConfig{
-						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JSONFilePath: docPath,
-						},
+						JSONFilePath: docPath,
 					},
 				),
-			),
+			)),
 		)
 		Get(s, "/", func(ContextNoBody) (MyStruct, error) {
 			return MyStruct{}, nil
@@ -270,16 +268,14 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 	})
 	t.Run("do not print file", func(t *testing.T) {
 		s := NewServer(
-			WithEngineOptions(
+			WithEngine(NewEngine(
 				WithOpenAPIConfig(
 					OpenAPIConfig{
-						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JSONFilePath:     docPath,
-							DisableLocalSave: true,
-						},
+						JSONFilePath:     docPath,
+						DisableLocalSave: true,
 					},
 				),
-			),
+			)),
 		)
 		Get(s, "/", func(ContextNoBody) (MyStruct, error) {
 			return MyStruct{}, nil
@@ -294,17 +290,15 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 	})
 	t.Run("swagger disabled", func(t *testing.T) {
 		s := NewServer(
-			WithEngineOptions(
+			WithEngine(NewEngine(
 				WithOpenAPIConfig(
 					OpenAPIConfig{
-						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JSONFilePath:     docPath,
-							DisableLocalSave: true,
-						},
-						DisableSwagger: true,
+						JSONFilePath:     docPath,
+						DisableLocalSave: true,
+						Disabled:         true,
 					},
 				),
-			),
+			)),
 		)
 		Get(s, "/", func(ContextNoBody) (MyStruct, error) {
 			return MyStruct{}, nil
@@ -320,16 +314,14 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 	})
 	t.Run("pretty format json file", func(t *testing.T) {
 		s := NewServer(
-			WithEngineOptions(
+			WithEngine(NewEngine(
 				WithOpenAPIConfig(
 					OpenAPIConfig{
-						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JSONFilePath:     docPath,
-							PrettyFormatJSON: true,
-						},
+						JSONFilePath:     docPath,
+						PrettyFormatJSON: true,
 					},
 				),
-			),
+			)),
 		)
 		Get(s, "/", func(ContextNoBody) (MyStruct, error) {
 			return MyStruct{}, nil
@@ -441,13 +433,15 @@ func TestLocalSave(t *testing.T) {
 
 func TestAutoGroupTags(t *testing.T) {
 	s := NewServer(
-		WithEngineOptions(
-			WithOpenAPIConfig(OpenAPIConfig{
-				EngineOpenAPIConfig: EngineOpenAPIConfig{
-					DisableLocalSave: true,
-				},
-				DisableSwagger: true,
-			}),
+		WithEngine(
+			NewEngine(
+				WithOpenAPIConfig(
+					OpenAPIConfig{
+						DisableLocalSave: true,
+						Disabled:         true,
+					},
+				),
+			),
 		),
 	)
 	Get(s, "/a", func(ContextNoBody) (MyStruct, error) {

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -249,7 +249,7 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 				WithOpenAPIConfig(
 					OpenAPIConfig{
 						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JsonFilePath: docPath,
+							JSONFilePath: docPath,
 						},
 					},
 				),
@@ -274,7 +274,7 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 				WithOpenAPIConfig(
 					OpenAPIConfig{
 						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JsonFilePath:     docPath,
+							JSONFilePath:     docPath,
 							DisableLocalSave: true,
 						},
 					},
@@ -298,7 +298,7 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 				WithOpenAPIConfig(
 					OpenAPIConfig{
 						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JsonFilePath:     docPath,
+							JSONFilePath:     docPath,
 							DisableLocalSave: true,
 						},
 						DisableSwagger: true,
@@ -324,8 +324,8 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 				WithOpenAPIConfig(
 					OpenAPIConfig{
 						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JsonFilePath:     docPath,
-							PrettyFormatJson: true,
+							JSONFilePath:     docPath,
+							PrettyFormatJSON: true,
 						},
 					},
 				),

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -245,12 +245,14 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 	docPath := "doc/openapi.json"
 	t.Run("base", func(t *testing.T) {
 		s := NewServer(
-			WithOpenAPIConfig(
-				OpenAPIConfig{
-					EngineOpenAPIConfig: EngineOpenAPIConfig{
-						JsonFilePath: docPath,
+			WithEngineOptions(
+				WithOpenAPIConfig(
+					OpenAPIConfig{
+						EngineOpenAPIConfig: EngineOpenAPIConfig{
+							JsonFilePath: docPath,
+						},
 					},
-				},
+				),
 			),
 		)
 		Get(s, "/", func(ContextNoBody) (MyStruct, error) {
@@ -268,13 +270,15 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 	})
 	t.Run("do not print file", func(t *testing.T) {
 		s := NewServer(
-			WithOpenAPIConfig(
-				OpenAPIConfig{
-					EngineOpenAPIConfig: EngineOpenAPIConfig{
-						JsonFilePath:     docPath,
-						DisableLocalSave: true,
+			WithEngineOptions(
+				WithOpenAPIConfig(
+					OpenAPIConfig{
+						EngineOpenAPIConfig: EngineOpenAPIConfig{
+							JsonFilePath:     docPath,
+							DisableLocalSave: true,
+						},
 					},
-				},
+				),
 			),
 		)
 		Get(s, "/", func(ContextNoBody) (MyStruct, error) {
@@ -290,14 +294,16 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 	})
 	t.Run("swagger disabled", func(t *testing.T) {
 		s := NewServer(
-			WithOpenAPIConfig(
-				OpenAPIConfig{
-					EngineOpenAPIConfig: EngineOpenAPIConfig{
-						JsonFilePath:     docPath,
-						DisableLocalSave: true,
+			WithEngineOptions(
+				WithOpenAPIConfig(
+					OpenAPIConfig{
+						EngineOpenAPIConfig: EngineOpenAPIConfig{
+							JsonFilePath:     docPath,
+							DisableLocalSave: true,
+						},
+						DisableSwagger: true,
 					},
-					DisableSwagger: true,
-				},
+				),
 			),
 		)
 		Get(s, "/", func(ContextNoBody) (MyStruct, error) {
@@ -314,13 +320,15 @@ func TestServer_OutputOpenApiSpec(t *testing.T) {
 	})
 	t.Run("pretty format json file", func(t *testing.T) {
 		s := NewServer(
-			WithOpenAPIConfig(
-				OpenAPIConfig{
-					EngineOpenAPIConfig: EngineOpenAPIConfig{
-						JsonFilePath:     docPath,
-						PrettyFormatJson: true,
+			WithEngineOptions(
+				WithOpenAPIConfig(
+					OpenAPIConfig{
+						EngineOpenAPIConfig: EngineOpenAPIConfig{
+							JsonFilePath:     docPath,
+							PrettyFormatJson: true,
+						},
 					},
-				},
+				),
 			),
 		)
 		Get(s, "/", func(ContextNoBody) (MyStruct, error) {
@@ -433,12 +441,14 @@ func TestLocalSave(t *testing.T) {
 
 func TestAutoGroupTags(t *testing.T) {
 	s := NewServer(
-		WithOpenAPIConfig(OpenAPIConfig{
-			EngineOpenAPIConfig: EngineOpenAPIConfig{
-				DisableLocalSave: true,
-			},
-			DisableSwagger: true,
-		}),
+		WithEngineOptions(
+			WithOpenAPIConfig(OpenAPIConfig{
+				EngineOpenAPIConfig: EngineOpenAPIConfig{
+					DisableLocalSave: true,
+				},
+				DisableSwagger: true,
+			}),
+		),
 	)
 	Get(s, "/a", func(ContextNoBody) (MyStruct, error) {
 		return MyStruct{}, nil

--- a/server.go
+++ b/server.go
@@ -21,19 +21,19 @@ type OpenAPIConfig struct {
 	// If true, the server will not serve the Swagger UI
 	DisableSwaggerUI bool
 	// URL to serve the swagger UI
-	SwaggerUrl string
+	SwaggerURL string
 	// Handler to serve the OpenAPI UI from spec URL
 	UIHandler func(specURL string) http.Handler
 	// URL to serve the OpenAPI JSON spec
-	JsonUrl string
+	JsonURL string
 }
 
 var defaultOpenAPIConfig = OpenAPIConfig{
-	SwaggerUrl: "/swagger",
-	JsonUrl:    "/swagger/openapi.json",
+	SwaggerURL: "/swagger",
+	JsonURL:    "/swagger/openapi.json",
 	UIHandler:  DefaultOpenAPIHandler,
 	EngineOpenAPIConfig: EngineOpenAPIConfig{
-		JsonFilePath: "doc/openapi.json",
+		JSONFilePath: "doc/openapi.json",
 	},
 }
 

--- a/server.go
+++ b/server.go
@@ -365,9 +365,11 @@ func WithoutLogger() func(*Server) {
 	}
 }
 
-func WithOpenAPIConfig(openapiConfig OpenAPIConfig) func(*Server) {
+func WithEngineOptions(options ...func(*Engine)) func(*Server) {
 	return func(s *Server) {
-		s.Engine.setOpenAPIConfig(openapiConfig)
+		for _, option := range options {
+			option(s.Engine)
+		}
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -15,21 +15,26 @@ import (
 )
 
 type OpenAPIConfig struct {
-	DisableSwagger   bool                              // If true, the server will not serve the Swagger UI nor the OpenAPI JSON spec
-	DisableSwaggerUI bool                              // If true, the server will not serve the Swagger UI
-	DisableLocalSave bool                              // If true, the server will not save the OpenAPI JSON spec locally
-	SwaggerUrl       string                            // URL to serve the swagger UI
-	UIHandler        func(specURL string) http.Handler // Handler to serve the OpenAPI UI from spec URL
-	JsonUrl          string                            // URL to serve the OpenAPI JSON spec
-	JsonFilePath     string                            // Local path to save the OpenAPI JSON spec
-	PrettyFormatJson bool                              // Pretty prints the OpenAPI spec with proper JSON indentation
+	EngineOpenAPIConfig
+	// If true, the server will not serve the Swagger UI nor the OpenAPI JSON spec
+	DisableSwagger bool
+	// If true, the server will not serve the Swagger UI
+	DisableSwaggerUI bool
+	// URL to serve the swagger UI
+	SwaggerUrl string
+	// Handler to serve the OpenAPI UI from spec URL
+	UIHandler func(specURL string) http.Handler
+	// URL to serve the OpenAPI JSON spec
+	JsonUrl string
 }
 
 var defaultOpenAPIConfig = OpenAPIConfig{
-	SwaggerUrl:   "/swagger",
-	JsonUrl:      "/swagger/openapi.json",
-	JsonFilePath: "doc/openapi.json",
-	UIHandler:    DefaultOpenAPIHandler,
+	SwaggerUrl: "/swagger",
+	JsonUrl:    "/swagger/openapi.json",
+	UIHandler:  DefaultOpenAPIHandler,
+	EngineOpenAPIConfig: EngineOpenAPIConfig{
+		JsonFilePath: "doc/openapi.json",
+	},
 }
 
 type Server struct {
@@ -75,8 +80,6 @@ type Server struct {
 
 	startTime time.Time
 
-	OpenAPIConfig OpenAPIConfig
-
 	isTLS bool
 }
 
@@ -100,8 +103,6 @@ func NewServer(options ...func(*Server)) *Server {
 		},
 		Mux:    http.NewServeMux(),
 		Engine: NewEngine(),
-
-		OpenAPIConfig: defaultOpenAPIConfig,
 
 		Security: NewSecurity(),
 	}
@@ -351,7 +352,10 @@ func WithErrorHandler(errorHandler func(err error) error) func(*Server) {
 
 // WithoutStartupMessages disables the startup message
 func WithoutStartupMessages() func(*Server) {
-	return func(c *Server) { c.disableStartupMessages = true }
+	return func(c *Server) {
+		c.disableStartupMessages = true
+		c.OpenAPIConfig.DisableMessages = true
+	}
 }
 
 // WithoutLogger disables the default logger.
@@ -363,36 +367,7 @@ func WithoutLogger() func(*Server) {
 
 func WithOpenAPIConfig(openapiConfig OpenAPIConfig) func(*Server) {
 	return func(s *Server) {
-		if openapiConfig.JsonUrl != "" {
-			s.OpenAPIConfig.JsonUrl = openapiConfig.JsonUrl
-		}
-
-		if openapiConfig.SwaggerUrl != "" {
-			s.OpenAPIConfig.SwaggerUrl = openapiConfig.SwaggerUrl
-		}
-
-		if openapiConfig.JsonFilePath != "" {
-			s.OpenAPIConfig.JsonFilePath = openapiConfig.JsonFilePath
-		}
-
-		if openapiConfig.UIHandler != nil {
-			s.OpenAPIConfig.UIHandler = openapiConfig.UIHandler
-		}
-
-		s.OpenAPIConfig.DisableSwagger = openapiConfig.DisableSwagger
-		s.OpenAPIConfig.DisableSwaggerUI = openapiConfig.DisableSwaggerUI
-		s.OpenAPIConfig.DisableLocalSave = openapiConfig.DisableLocalSave
-		s.OpenAPIConfig.PrettyFormatJson = openapiConfig.PrettyFormatJson
-
-		if !validateJsonSpecUrl(s.OpenAPIConfig.JsonUrl) {
-			slog.Error("Error serving openapi json spec. Value of 's.OpenAPIConfig.JsonSpecUrl' option is not valid", "url", s.OpenAPIConfig.JsonUrl)
-			return
-		}
-
-		if !validateSwaggerUrl(s.OpenAPIConfig.SwaggerUrl) {
-			slog.Error("Error serving swagger ui. Value of 's.OpenAPIConfig.SwaggerUrl' option is not valid", "url", s.OpenAPIConfig.SwaggerUrl)
-			return
-		}
+		s.Engine.setOpenAPIConfig(openapiConfig)
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -83,12 +83,14 @@ func TestWithOpenAPIConfig(t *testing.T) {
 	t.Run("with custom values", func(t *testing.T) {
 		s := NewServer(
 			WithOpenAPIConfig(OpenAPIConfig{
-				SwaggerUrl:       "/api",
-				JsonUrl:          "/api/openapi.json",
-				JsonFilePath:     "openapi.json",
-				DisableSwagger:   true,
-				DisableLocalSave: true,
-				PrettyFormatJson: true,
+				SwaggerUrl:     "/api",
+				JsonUrl:        "/api/openapi.json",
+				DisableSwagger: true,
+				EngineOpenAPIConfig: EngineOpenAPIConfig{
+					JsonFilePath:     "openapi.json",
+					DisableLocalSave: true,
+					PrettyFormatJson: true,
+				},
 			}),
 		)
 
@@ -104,18 +106,22 @@ func TestWithOpenAPIConfig(t *testing.T) {
 		t.Run("with invalid path", func(t *testing.T) {
 			NewServer(
 				WithOpenAPIConfig(OpenAPIConfig{
-					JsonFilePath: "path/to/jsonSpec",
-					SwaggerUrl:   "p   i",
-					JsonUrl:      "pi/op  enapi.json",
+					SwaggerUrl: "p   i",
+					JsonUrl:    "pi/op  enapi.json",
+					EngineOpenAPIConfig: EngineOpenAPIConfig{
+						JsonFilePath: "path/to/jsonSpec",
+					},
 				}),
 			)
 		})
 		t.Run("with invalid url", func(t *testing.T) {
 			NewServer(
 				WithOpenAPIConfig(OpenAPIConfig{
-					JsonFilePath: "path/to/jsonSpec.json",
-					JsonUrl:      "pi/op  enapi.json",
-					SwaggerUrl:   "p   i",
+					JsonUrl:    "pi/op  enapi.json",
+					SwaggerUrl: "p   i",
+					EngineOpenAPIConfig: EngineOpenAPIConfig{
+						JsonFilePath: "path/to/jsonSpec.json",
+					},
 				}),
 			)
 		})
@@ -123,9 +129,11 @@ func TestWithOpenAPIConfig(t *testing.T) {
 		t.Run("with invalid url", func(t *testing.T) {
 			NewServer(
 				WithOpenAPIConfig(OpenAPIConfig{
-					JsonFilePath: "path/to/jsonSpec.json",
-					JsonUrl:      "/api/openapi.json",
-					SwaggerUrl:   "invalid path",
+					JsonUrl:    "/api/openapi.json",
+					SwaggerUrl: "invalid path",
+					EngineOpenAPIConfig: EngineOpenAPIConfig{
+						JsonFilePath: "path/to/jsonSpec.json",
+					},
 				}),
 			)
 		})
@@ -269,6 +277,7 @@ func TestWithoutStartupMessages(t *testing.T) {
 	)
 
 	require.True(t, s.disableStartupMessages)
+	require.True(t, s.Engine.OpenAPIConfig.DisableMessages)
 }
 
 func TestWithoutAutoGroupTags(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -71,7 +71,9 @@ func TestWithXML(t *testing.T) {
 func TestWithOpenAPIConfig(t *testing.T) {
 	t.Run("with default values", func(t *testing.T) {
 		s := NewServer(
-			WithOpenAPIConfig(OpenAPIConfig{}),
+			WithEngineOptions(
+				WithOpenAPIConfig(OpenAPIConfig{}),
+			),
 		)
 
 		require.Equal(t, "/swagger", s.OpenAPIConfig.SwaggerUrl)
@@ -82,16 +84,18 @@ func TestWithOpenAPIConfig(t *testing.T) {
 
 	t.Run("with custom values", func(t *testing.T) {
 		s := NewServer(
-			WithOpenAPIConfig(OpenAPIConfig{
-				SwaggerUrl:     "/api",
-				JsonUrl:        "/api/openapi.json",
-				DisableSwagger: true,
-				EngineOpenAPIConfig: EngineOpenAPIConfig{
-					JsonFilePath:     "openapi.json",
-					DisableLocalSave: true,
-					PrettyFormatJson: true,
-				},
-			}),
+			WithEngineOptions(
+				WithOpenAPIConfig(OpenAPIConfig{
+					SwaggerUrl:     "/api",
+					JsonUrl:        "/api/openapi.json",
+					DisableSwagger: true,
+					EngineOpenAPIConfig: EngineOpenAPIConfig{
+						JsonFilePath:     "openapi.json",
+						DisableLocalSave: true,
+						PrettyFormatJson: true,
+					},
+				}),
+			),
 		)
 
 		require.Equal(t, "/api", s.OpenAPIConfig.SwaggerUrl)
@@ -105,36 +109,42 @@ func TestWithOpenAPIConfig(t *testing.T) {
 	t.Run("with invalid local path values", func(t *testing.T) {
 		t.Run("with invalid path", func(t *testing.T) {
 			NewServer(
-				WithOpenAPIConfig(OpenAPIConfig{
-					SwaggerUrl: "p   i",
-					JsonUrl:    "pi/op  enapi.json",
-					EngineOpenAPIConfig: EngineOpenAPIConfig{
-						JsonFilePath: "path/to/jsonSpec",
-					},
-				}),
+				WithEngineOptions(
+					WithOpenAPIConfig(OpenAPIConfig{
+						SwaggerUrl: "p   i",
+						JsonUrl:    "pi/op  enapi.json",
+						EngineOpenAPIConfig: EngineOpenAPIConfig{
+							JsonFilePath: "path/to/jsonSpec",
+						},
+					}),
+				),
 			)
 		})
 		t.Run("with invalid url", func(t *testing.T) {
 			NewServer(
-				WithOpenAPIConfig(OpenAPIConfig{
-					JsonUrl:    "pi/op  enapi.json",
-					SwaggerUrl: "p   i",
-					EngineOpenAPIConfig: EngineOpenAPIConfig{
-						JsonFilePath: "path/to/jsonSpec.json",
-					},
-				}),
+				WithEngineOptions(
+					WithOpenAPIConfig(OpenAPIConfig{
+						JsonUrl:    "pi/op  enapi.json",
+						SwaggerUrl: "p   i",
+						EngineOpenAPIConfig: EngineOpenAPIConfig{
+							JsonFilePath: "path/to/jsonSpec.json",
+						},
+					}),
+				),
 			)
 		})
 
 		t.Run("with invalid url", func(t *testing.T) {
 			NewServer(
-				WithOpenAPIConfig(OpenAPIConfig{
-					JsonUrl:    "/api/openapi.json",
-					SwaggerUrl: "invalid path",
-					EngineOpenAPIConfig: EngineOpenAPIConfig{
-						JsonFilePath: "path/to/jsonSpec.json",
-					},
-				}),
+				WithEngineOptions(
+					WithOpenAPIConfig(OpenAPIConfig{
+						JsonUrl:    "/api/openapi.json",
+						SwaggerUrl: "invalid path",
+						EngineOpenAPIConfig: EngineOpenAPIConfig{
+							JsonFilePath: "path/to/jsonSpec.json",
+						},
+					}),
+				),
 			)
 		})
 	})

--- a/server_test.go
+++ b/server_test.go
@@ -71,81 +71,76 @@ func TestWithXML(t *testing.T) {
 func TestWithOpenAPIConfig(t *testing.T) {
 	t.Run("with default values", func(t *testing.T) {
 		s := NewServer(
-			WithEngineOptions(
-				WithOpenAPIConfig(OpenAPIConfig{}),
-			),
+			WithOpenAPIServerConfig(OpenAPIServerConfig{}),
 		)
 
-		require.Equal(t, "/swagger", s.OpenAPIConfig.SwaggerURL)
-		require.Equal(t, "/swagger/openapi.json", s.OpenAPIConfig.JsonURL)
-		require.Equal(t, "doc/openapi.json", s.OpenAPIConfig.JSONFilePath)
-		require.False(t, s.OpenAPIConfig.PrettyFormatJSON)
+		require.Equal(t, "/swagger", s.OpenAPIServerConfig.SwaggerURL)
+		require.Equal(t, "/swagger/openapi.json", s.OpenAPIServerConfig.JsonURL)
+		require.Equal(t, "doc/openapi.json", s.Engine.OpenAPIConfig.JSONFilePath)
+		require.False(t, s.Engine.OpenAPIConfig.PrettyFormatJSON)
 	})
 
 	t.Run("with custom values", func(t *testing.T) {
 		s := NewServer(
-			WithEngineOptions(
+			WithEngine(NewEngine(
 				WithOpenAPIConfig(OpenAPIConfig{
-					SwaggerURL:     "/api",
-					JsonURL:        "/api/openapi.json",
-					DisableSwagger: true,
-					EngineOpenAPIConfig: EngineOpenAPIConfig{
-						JSONFilePath:     "openapi.json",
-						DisableLocalSave: true,
-						PrettyFormatJSON: true,
-					},
+					JSONFilePath:     "openapi.json",
+					DisableLocalSave: true,
+					PrettyFormatJSON: true,
+					Disabled:         true,
 				}),
-			),
+			)),
+			WithOpenAPIServerConfig(OpenAPIServerConfig{
+				SwaggerURL: "/api",
+				JsonURL:    "/api/openapi.json",
+			}),
 		)
 
-		require.Equal(t, "/api", s.OpenAPIConfig.SwaggerURL)
-		require.Equal(t, "/api/openapi.json", s.OpenAPIConfig.JsonURL)
-		require.Equal(t, "openapi.json", s.OpenAPIConfig.JSONFilePath)
-		require.True(t, s.OpenAPIConfig.DisableSwagger)
-		require.True(t, s.OpenAPIConfig.DisableLocalSave)
-		require.True(t, s.OpenAPIConfig.PrettyFormatJSON)
+		require.Equal(t, "/api", s.OpenAPIServerConfig.SwaggerURL)
+		require.Equal(t, "/api/openapi.json", s.OpenAPIServerConfig.JsonURL)
+		require.Equal(t, "openapi.json", s.Engine.OpenAPIConfig.JSONFilePath)
+		require.True(t, s.Engine.OpenAPIConfig.Disabled)
+		require.True(t, s.Engine.OpenAPIConfig.DisableLocalSave)
+		require.True(t, s.Engine.OpenAPIConfig.PrettyFormatJSON)
 	})
 
 	t.Run("with invalid local path values", func(t *testing.T) {
 		t.Run("with invalid path", func(t *testing.T) {
 			NewServer(
-				WithEngineOptions(
+				WithEngine(NewEngine(
 					WithOpenAPIConfig(OpenAPIConfig{
-						SwaggerURL: "p   i",
-						JsonURL:    "pi/op  enapi.json",
-						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JSONFilePath: "path/to/jsonSpec",
-						},
+						JSONFilePath: "path/to/jsonSpec",
 					}),
-				),
-			)
+				)),
+				WithOpenAPIServerConfig(OpenAPIServerConfig{
+					SwaggerURL: "p   i",
+					JsonURL:    "pi/op  enapi.json",
+				}))
 		})
 		t.Run("with invalid url", func(t *testing.T) {
 			NewServer(
-				WithEngineOptions(
+				WithEngine(NewEngine(
 					WithOpenAPIConfig(OpenAPIConfig{
-						JsonURL:    "pi/op  enapi.json",
-						SwaggerURL: "p   i",
-						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JSONFilePath: "path/to/jsonSpec.json",
-						},
+						JSONFilePath: "path/to/jsonSpec.json",
 					}),
-				),
-			)
+				)),
+				WithOpenAPIServerConfig(OpenAPIServerConfig{
+					JsonURL:    "pi/op  enapi.json",
+					SwaggerURL: "p   i",
+				}))
 		})
 
 		t.Run("with invalid url", func(t *testing.T) {
 			NewServer(
-				WithEngineOptions(
+				WithEngine(NewEngine(
 					WithOpenAPIConfig(OpenAPIConfig{
-						JsonURL:    "/api/openapi.json",
-						SwaggerURL: "invalid path",
-						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JSONFilePath: "path/to/jsonSpec.json",
-						},
+						JSONFilePath: "path/to/jsonSpec.json",
 					}),
-				),
-			)
+				)),
+				WithOpenAPIServerConfig(OpenAPIServerConfig{
+					JsonURL:    "/api/openapi.json",
+					SwaggerURL: "invalid path",
+				}))
 		})
 	})
 }

--- a/server_test.go
+++ b/server_test.go
@@ -76,34 +76,34 @@ func TestWithOpenAPIConfig(t *testing.T) {
 			),
 		)
 
-		require.Equal(t, "/swagger", s.OpenAPIConfig.SwaggerUrl)
-		require.Equal(t, "/swagger/openapi.json", s.OpenAPIConfig.JsonUrl)
-		require.Equal(t, "doc/openapi.json", s.OpenAPIConfig.JsonFilePath)
-		require.False(t, s.OpenAPIConfig.PrettyFormatJson)
+		require.Equal(t, "/swagger", s.OpenAPIConfig.SwaggerURL)
+		require.Equal(t, "/swagger/openapi.json", s.OpenAPIConfig.JsonURL)
+		require.Equal(t, "doc/openapi.json", s.OpenAPIConfig.JSONFilePath)
+		require.False(t, s.OpenAPIConfig.PrettyFormatJSON)
 	})
 
 	t.Run("with custom values", func(t *testing.T) {
 		s := NewServer(
 			WithEngineOptions(
 				WithOpenAPIConfig(OpenAPIConfig{
-					SwaggerUrl:     "/api",
-					JsonUrl:        "/api/openapi.json",
+					SwaggerURL:     "/api",
+					JsonURL:        "/api/openapi.json",
 					DisableSwagger: true,
 					EngineOpenAPIConfig: EngineOpenAPIConfig{
-						JsonFilePath:     "openapi.json",
+						JSONFilePath:     "openapi.json",
 						DisableLocalSave: true,
-						PrettyFormatJson: true,
+						PrettyFormatJSON: true,
 					},
 				}),
 			),
 		)
 
-		require.Equal(t, "/api", s.OpenAPIConfig.SwaggerUrl)
-		require.Equal(t, "/api/openapi.json", s.OpenAPIConfig.JsonUrl)
-		require.Equal(t, "openapi.json", s.OpenAPIConfig.JsonFilePath)
+		require.Equal(t, "/api", s.OpenAPIConfig.SwaggerURL)
+		require.Equal(t, "/api/openapi.json", s.OpenAPIConfig.JsonURL)
+		require.Equal(t, "openapi.json", s.OpenAPIConfig.JSONFilePath)
 		require.True(t, s.OpenAPIConfig.DisableSwagger)
 		require.True(t, s.OpenAPIConfig.DisableLocalSave)
-		require.True(t, s.OpenAPIConfig.PrettyFormatJson)
+		require.True(t, s.OpenAPIConfig.PrettyFormatJSON)
 	})
 
 	t.Run("with invalid local path values", func(t *testing.T) {
@@ -111,10 +111,10 @@ func TestWithOpenAPIConfig(t *testing.T) {
 			NewServer(
 				WithEngineOptions(
 					WithOpenAPIConfig(OpenAPIConfig{
-						SwaggerUrl: "p   i",
-						JsonUrl:    "pi/op  enapi.json",
+						SwaggerURL: "p   i",
+						JsonURL:    "pi/op  enapi.json",
 						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JsonFilePath: "path/to/jsonSpec",
+							JSONFilePath: "path/to/jsonSpec",
 						},
 					}),
 				),
@@ -124,10 +124,10 @@ func TestWithOpenAPIConfig(t *testing.T) {
 			NewServer(
 				WithEngineOptions(
 					WithOpenAPIConfig(OpenAPIConfig{
-						JsonUrl:    "pi/op  enapi.json",
-						SwaggerUrl: "p   i",
+						JsonURL:    "pi/op  enapi.json",
+						SwaggerURL: "p   i",
 						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JsonFilePath: "path/to/jsonSpec.json",
+							JSONFilePath: "path/to/jsonSpec.json",
 						},
 					}),
 				),
@@ -138,10 +138,10 @@ func TestWithOpenAPIConfig(t *testing.T) {
 			NewServer(
 				WithEngineOptions(
 					WithOpenAPIConfig(OpenAPIConfig{
-						JsonUrl:    "/api/openapi.json",
-						SwaggerUrl: "invalid path",
+						JsonURL:    "/api/openapi.json",
+						SwaggerURL: "invalid path",
 						EngineOpenAPIConfig: EngineOpenAPIConfig{
-							JsonFilePath: "path/to/jsonSpec.json",
+							JSONFilePath: "path/to/jsonSpec.json",
 						},
 					}),
 				),


### PR DESCRIPTION
Opened a PR to give a look at the WithEngine concept. 

I personally like this bit better than the WithEngineOptions as we're able to separate the the two different types of `OpenAPIConfig` and `OpenAPIServerConfig`. It also will make for less impactful if we decide to move more `OpenAPIServerConfig` options into the engine `OpenAPIConfig`.

Also having such a well tested code base makes this code so nice to work with