### PR TITLE
re-implementing default logging middleware

### DIFF
--- a/default_middlewares.go
+++ b/default_middlewares.go
@@ -1,0 +1,109 @@
+package fuego
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type LoggingConfig struct {
+	DisableRequest  bool // If true, request logging is disabled
+	DisableResponse bool // If true, response logging is disabled
+}
+
+// responseWriter wraps [http.ResponseWriter] to capture response metadata.
+// Implements [http.ResponseWriter.Write] to ensure proper status code capture for implicit 200 responses
+type responseWriter struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func wrapResponseWriter(w http.ResponseWriter) *responseWriter {
+	return &responseWriter{ResponseWriter: w}
+}
+
+func (rw *responseWriter) Status() int {
+	return rw.status
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	if rw.wroteHeader {
+		return
+	}
+
+	rw.status = code
+	rw.ResponseWriter.WriteHeader(code)
+	rw.wroteHeader = true
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	if !rw.wroteHeader {
+		rw.WriteHeader(http.StatusOK)
+	}
+	return rw.ResponseWriter.Write(b)
+}
+
+func (l *LoggingConfig) Disabled() bool {
+	return l.DisableRequest && l.DisableResponse
+}
+
+// By default, all logging is enabled
+var defaultLoggingConfig = LoggingConfig{}
+
+// defaultLoggingMiddleware is this default middleware that logs incoming requests and outgoing responses.
+//
+// By default, request logging will be logged at the debug level, and response
+// logging will be logged at the info level
+//
+// Log levels managed by [WithLogHandler]
+func defaultLoggingMiddleware(s *Server) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+
+			requestID := r.Header.Get("X-Request-ID")
+			if requestID == "" {
+				requestID = uuid.New().String()
+			}
+			w.Header().Set("X-Request-ID", requestID)
+
+			wrapped := wrapResponseWriter(w)
+
+			if !s.loggingConfig.DisableRequest {
+				logRequest(requestID, r)
+			}
+
+			next.ServeHTTP(wrapped, r)
+
+			if !s.loggingConfig.DisableResponse {
+				duration := time.Since(start)
+				logResponse(r, wrapped, requestID, duration)
+			}
+		})
+	}
+}
+
+func logRequest(requestID string, r *http.Request) {
+	slog.Debug("incoming request",
+		"request_id", requestID,
+		"method", r.Method,
+		"path", r.URL.Path,
+		"timestamp", time.Now().Format(time.RFC3339),
+		"remote_addr", r.RemoteAddr,
+		"user_agent", r.UserAgent(),
+	)
+}
+
+func logResponse(r *http.Request, rw *responseWriter, requestID string, duration time.Duration) {
+	slog.Info("outgoing response",
+		"request_id", requestID,
+		"method", r.Method,
+		"path", r.URL.Path,
+		"timestamp", time.Now().Format(time.RFC3339),
+		"duration_ms", duration.Milliseconds(),
+		"status_code", rw.status,
+	)
+}

--- a/default_middlewares.go
+++ b/default_middlewares.go
@@ -60,10 +60,6 @@ func newResponseWriter(w http.ResponseWriter) *responseWriter {
 	return &responseWriter{ResponseWriter: w}
 }
 
-func (rw *responseWriter) Status() int {
-	return rw.status
-}
-
 func (rw *responseWriter) WriteHeader(code int) {
 	if rw.wroteHeader {
 		return

--- a/default_middlewares.go
+++ b/default_middlewares.go
@@ -21,15 +21,15 @@ var defaultLoggingConfig = LoggingConfig{
 // For example:
 //
 //	config := fuego.LoggingConfig{
-//		    DisableRequest:  false,
+//		    DisableRequest:  true,
 //		    RequestIDFunc: func() string {
 //		        return fmt.Sprintf("custom-%d", time.Now().UnixNano())
 //		    },
 //		}
 //
 // The above configuration will disable the debug request logging and
-// override the default request ID generator with a custom one that
-// appends the current Unix time in nanoseconds
+// override the default request ID generator (UUID) with a custom one that
+// appends the current Unix time in nanoseconds for response logs
 type LoggingConfig struct {
 	// If true, request logging is disabled
 	DisableRequest bool

--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -155,7 +155,7 @@
 	"paths": {
 		"/pets/": {
 			"get": {
-				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.filterPets`\n\n---\n\nFilter pets",
+				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.filterPets`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\nFilter pets",
 				"operationId": "GET_/pets/",
 				"parameters": [
 					{
@@ -330,7 +330,7 @@
 				]
 			},
 			"post": {
-				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.postPets`\n\n---\n\n",
+				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.postPets`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\n",
 				"operationId": "POST_/pets/",
 				"parameters": [
 					{
@@ -448,7 +448,7 @@
 		},
 		"/pets/all": {
 			"get": {
-				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.getAllPets`\n\n---\n\nGet all pets",
+				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.getAllPets`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\nGet all pets",
 				"operationId": "GET_/pets/all",
 				"parameters": [
 					{
@@ -603,7 +603,7 @@
 		},
 		"/pets/by-age": {
 			"get": {
-				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.getAllPetsByAge`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego/examples/petstore/controllers.dummyMiddleware`\n\n---\n\nReturns an array of pets grouped by age",
+				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.getAllPetsByAge`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n- `github.com/go-fuego/fuego/examples/petstore/controllers.dummyMiddleware`\n\n---\n\nReturns an array of pets grouped by age",
 				"operationId": "GET_/pets/by-age",
 				"parameters": [
 					{
@@ -707,7 +707,7 @@
 		},
 		"/pets/by-name/{name...}": {
 			"get": {
-				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.getPetByName`\n\n---\n\n",
+				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.getPetByName`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\n",
 				"operationId": "GET_/pets/by-name/:name...",
 				"parameters": [
 					{
@@ -808,7 +808,7 @@
 		},
 		"/pets/std/all": {
 			"get": {
-				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.Routes.func1`\n\n---\n\n",
+				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.Routes.func1`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\n",
 				"operationId": "GET_/pets/std/all",
 				"parameters": [
 					{
@@ -892,7 +892,7 @@
 		},
 		"/pets/{id}": {
 			"delete": {
-				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.deletePets`\n\n---\n\n",
+				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.deletePets`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\n",
 				"operationId": "DELETE_/pets/:id",
 				"parameters": [
 					{
@@ -1094,7 +1094,7 @@
 				]
 			},
 			"put": {
-				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.putPets`\n\n---\n\n",
+				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.putPets`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\n",
 				"operationId": "PUT_/pets/:id",
 				"parameters": [
 					{
@@ -1205,7 +1205,7 @@
 		},
 		"/pets/{id}/json": {
 			"put": {
-				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.putPets`\n\n---\n\n",
+				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.putPets`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\n",
 				"operationId": "PUT_/pets/:id/json",
 				"parameters": [
 					{

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/getkin/kin-openapi v0.128.0
 	github.com/go-playground/validator/v10 v10.23.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/schema v1.4.1
 	github.com/stretchr/testify v1.10.0
 	github.com/thejerf/slogassert v0.3.4

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17w
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/schema v1.4.1 h1:jUg5hUjCSDZpNGLuXQOgIWGdlgrIdYvgQ0wZtdK1M3E=
 github.com/gorilla/schema v1.4.1/go.mod h1:Dg5SSm5PV60mhF2NFaTV1xuYYj8tV8NOPRo4FggUMnM=
 github.com/invopop/yaml v0.3.1 h1:f0+ZpmhfBSS4MhG+4HYseMdJhoeeopbSKbq5Rpeelso=

--- a/openapi_operations_test.go
+++ b/openapi_operations_test.go
@@ -17,7 +17,7 @@ func TestTags(t *testing.T) {
 	)
 
 	require.Equal(t, []string{"my-tag"}, route.Operation.Tags)
-	require.Equal(t, "#### Controller: \n\n`github.com/go-fuego/fuego.testController`\n\n---\n\nmy description", route.Operation.Description)
+	require.Equal(t, "#### Controller: \n\n`github.com/go-fuego/fuego.testController`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\nmy description", route.Operation.Description)
 	require.Equal(t, "my summary", route.Operation.Summary)
 	require.Equal(t, true, route.Operation.Deprecated)
 }

--- a/option_test.go
+++ b/option_test.go
@@ -241,7 +241,7 @@ func TestOpenAPI(t *testing.T) {
 		)
 
 		require.Equal(t, "test summary", route.Operation.Summary)
-		require.Equal(t, "#### Controller: \n\n`github.com/go-fuego/fuego_test.helloWorld`\n\n---\n\ntest description", route.Operation.Description)
+		require.Equal(t, "#### Controller: \n\n`github.com/go-fuego/fuego_test.helloWorld`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\ntest description", route.Operation.Description)
 		require.Equal(t, []string{"first-tag", "second-tag"}, route.Operation.Tags)
 		require.True(t, route.Operation.Deprecated)
 	})
@@ -788,7 +788,7 @@ func TestOptionDescription(t *testing.T) {
 			option.Description("test description"),
 		)
 
-		require.Equal(t, "#### Controller: \n\n`github.com/go-fuego/fuego_test.helloWorld`\n\n---\n\ntest description", route.Operation.Description)
+		require.Equal(t, "#### Controller: \n\n`github.com/go-fuego/fuego_test.helloWorld`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\ntest description", route.Operation.Description)
 	})
 
 	t.Run("Override Fuego's description for the route", func(t *testing.T) {
@@ -809,11 +809,11 @@ func TestOptionDescription(t *testing.T) {
 			option.Description("another description"),
 		)
 
-		require.Equal(t, "#### Controller: \n\n`github.com/go-fuego/fuego_test.helloWorld`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego_test.dummyMiddleware`\n\n---\n\nanother description", route.Operation.Description)
+		require.Equal(t, "#### Controller: \n\n`github.com/go-fuego/fuego_test.helloWorld`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n- `github.com/go-fuego/fuego_test.dummyMiddleware`\n\n---\n\nanother description", route.Operation.Description)
 	})
 
 	t.Run("Add description to the route, route middleware is included", func(t *testing.T) {
-		s := fuego.NewServer()
+		s := fuego.NewServer() // Default logger middleware is added
 
 		fuego.Use(s, dummyMiddleware)
 
@@ -824,12 +824,11 @@ func TestOptionDescription(t *testing.T) {
 		route := fuego.Get(s, "/test", helloWorld,
 			option.Middleware(dummyMiddleware),
 			option.Description("another description"),
-			option.Middleware(dummyMiddleware), // After the description
-			option.Middleware(dummyMiddleware), // 6th middleware
+			option.Middleware(dummyMiddleware), // After the description (6th middleware)
 			option.Middleware(dummyMiddleware), // 7th middleware, should not be included
 		)
 
-		require.Equal(t, "#### Controller: \n\n`github.com/go-fuego/fuego_test.helloWorld`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego_test.dummyMiddleware`\n- `github.com/go-fuego/fuego_test.dummyMiddleware`\n- `github.com/go-fuego/fuego_test.dummyMiddleware`\n- `github.com/go-fuego/fuego_test.dummyMiddleware`\n- `github.com/go-fuego/fuego_test.dummyMiddleware`\n- more middleware…\n\n---\n\nanother description", route.Operation.Description)
+		require.Equal(t, "#### Controller: \n\n`github.com/go-fuego/fuego_test.helloWorld`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n- `github.com/go-fuego/fuego_test.dummyMiddleware`\n- `github.com/go-fuego/fuego_test.dummyMiddleware`\n- `github.com/go-fuego/fuego_test.dummyMiddleware`\n- `github.com/go-fuego/fuego_test.dummyMiddleware`\n- more middleware…\n\n---\n\nanother description", route.Operation.Description)
 	})
 }
 

--- a/server.go
+++ b/server.go
@@ -437,5 +437,8 @@ func WithLoggingMiddleware(loggingConfig LoggingConfig) func(*Server) {
 	return func(s *Server) {
 		s.loggingConfig.DisableRequest = loggingConfig.DisableRequest
 		s.loggingConfig.DisableResponse = loggingConfig.DisableResponse
+		if loggingConfig.RequestIDFunc != nil {
+			s.loggingConfig.RequestIDFunc = loggingConfig.RequestIDFunc
+		}
 	}
 }

--- a/server.go
+++ b/server.go
@@ -149,7 +149,7 @@ func NewServer(options ...func(*Server)) *Server {
 	}
 
 	if !s.loggingConfig.Disabled() {
-		s.middlewares = append(s.middlewares, defaultLoggingMiddleware(s))
+		s.middlewares = append(s.middlewares, newDefaultLogger(s).middleware)
 	}
 
 	return s

--- a/server.go
+++ b/server.go
@@ -77,6 +77,8 @@ type Server struct {
 
 	OpenAPIConfig OpenAPIConfig
 
+	loggingConfig LoggingConfig
+
 	isTLS bool
 }
 
@@ -104,6 +106,8 @@ func NewServer(options ...func(*Server)) *Server {
 		OpenAPIConfig: defaultOpenAPIConfig,
 
 		Security: NewSecurity(),
+
+		loggingConfig: defaultLoggingConfig,
 	}
 
 	// Default options that can be overridden
@@ -142,6 +146,10 @@ func NewServer(options ...func(*Server)) *Server {
 			OptionTags("Auth"),
 			OptionSummary("Refresh"),
 		)
+	}
+
+	if !s.loggingConfig.Disabled() {
+		s.middlewares = append(s.middlewares, defaultLoggingMiddleware(s))
 	}
 
 	return s
@@ -421,5 +429,13 @@ func WithValidator(newValidator *validator.Validate) func(*Server) {
 func WithRouteOptions(options ...func(*BaseRoute)) func(*Server) {
 	return func(s *Server) {
 		s.routeOptions = append(s.routeOptions, options...)
+	}
+}
+
+// WithLoggingMiddleware configures the default logging middleware for the server.
+func WithLoggingMiddleware(loggingConfig LoggingConfig) func(*Server) {
+	return func(s *Server) {
+		s.loggingConfig.DisableRequest = loggingConfig.DisableRequest
+		s.loggingConfig.DisableResponse = loggingConfig.DisableResponse
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -771,5 +771,4 @@ func TestDefaultLoggingMiddleware(t *testing.T) {
 			handler.AssertEmpty()
 		})
 	}
-
 }


### PR DESCRIPTION
This PR implements a simplified default logging middleware, taking on feedback from #303.

These changes simplify #303 and just provides default req/res logging, with options to disable either. Rather than supporting custom logging functions, users who need custom logging can just implement their own mw.

I see some of these use cases:
1. Use default middleware entirely
2. Disable fully/partially disable req&res logging
3. Disable and implement their own logging middleware
4. Use our middleware but override logging funcs

After thinking about how to do this, supporting case 4 does seems unnecessary and more complex that it needs to be - for users needing custom logging it would be cleaner to just implement their own.

Note: Some tests are failing for now due to some golden files not expecting this new middleware by default. 
