### PR TITLE
BREAKING: WithErrorHandler server option to engine option

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -71,6 +71,17 @@ func WithOpenAPIConfig(config OpenAPIConfig) func(*Engine) {
 	}
 }
 
+// WithErrorHandler sets a customer error handler for the server
+func WithErrorHandler(errorHandler func(err error) error) func(*Engine) {
+	return func(e *Engine) {
+		if errorHandler == nil {
+			panic("errorHandler cannot be nil")
+		}
+
+		e.ErrorHandler = errorHandler
+	}
+}
+
 // OutputOpenAPISpec takes the OpenAPI spec and outputs it to a JSON file
 func (e *Engine) OutputOpenAPISpec() []byte {
 	e.OpenAPI.computeTags()

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,0 +1,40 @@
+package fuego
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithErrorHandler(t *testing.T) {
+	t.Run("default engine", func(t *testing.T) {
+		e := NewEngine()
+		err := NotFoundError{
+			Err: errors.New("Not Found :c"),
+		}
+		errResponse := e.ErrorHandler(err)
+		require.ErrorAs(t, errResponse, &HTTPError{})
+	})
+	t.Run("custom handler", func(t *testing.T) {
+		e := NewEngine(
+			WithErrorHandler(func(err error) error {
+				return fmt.Errorf("%w foobar", err)
+			}),
+		)
+		err := NotFoundError{
+			Err: errors.New("Not Found :c"),
+		}
+		errResponse := e.ErrorHandler(err)
+		require.ErrorAs(t, errResponse, &HTTPError{})
+		require.ErrorContains(t, errResponse, "Not Found :c foobar")
+	})
+	t.Run("should be fatal", func(t *testing.T) {
+		require.Panics(t, func() {
+			NewEngine(
+				WithErrorHandler(nil),
+			)
+		})
+	})
+}

--- a/server.go
+++ b/server.go
@@ -351,11 +351,6 @@ func WithErrorSerializer(serializer ErrorSender) func(*Server) {
 	return func(c *Server) { c.SerializeError = serializer }
 }
 
-// WithErrorHandler sets a customer error handler for the server
-func WithErrorHandler(errorHandler func(err error) error) func(*Server) {
-	return func(c *Server) { c.ErrorHandler = errorHandler }
-}
-
 // WithoutStartupMessages disables the startup message
 func WithoutStartupMessages() func(*Server) {
 	return func(c *Server) {


### PR DESCRIPTION
Moves WithErrorHandler to an engine option.

Closed #314 in favor of this as I created a mess over there.