### PR TITLE
chore: issue 321 (Wrap Errors where applicable)

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -3,7 +3,6 @@ package fuego
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -152,18 +151,18 @@ func (s *Server) saveOpenAPIToFile(jsonSpecLocalPath string, jsonSpec []byte) er
 
 	err := os.MkdirAll(jsonFolder, 0o750)
 	if err != nil {
-		return errors.New("error creating docs directory")
+		return fmt.Errorf("error creating docs directory: %w", err)
 	}
 
 	f, err := os.Create(jsonSpecLocalPath) // #nosec G304 (file path provided by developer, not by user)
 	if err != nil {
-		return errors.New("error creating file")
+		return fmt.Errorf("error creating file: %w", err)
 	}
 	defer f.Close()
 
 	_, err = f.Write(jsonSpec)
 	if err != nil {
-		return errors.New("error writing file ")
+		return fmt.Errorf("error writing file: %w", err)
 	}
 
 	s.printOpenAPIMessage("JSON file: " + jsonSpecLocalPath)


### PR DESCRIPTION
### Summary
This pull requests wraps the errors on the `saveOpenAPIToFile(jsonSpecLocalPath string, jsonSpec []byte)` for better traceability and debugging 

### Issue
Addresses this issue [321](https://github.com/go-fuego/fuego/issues/321)

