### PR TITLE
refactor: change occurrences of A(a)cceptedContentTypes to R(r)equestContentTypes

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -39,7 +39,7 @@ type Engine struct {
 	ErrorHandler  func(error) error
 	OpenAPIConfig OpenAPIConfig
 
-	acceptedContentTypes []string
+	requestContentTypes []string
 }
 
 type OpenAPIConfig struct {
@@ -62,7 +62,7 @@ var defaultOpenAPIConfig = OpenAPIConfig{
 // WithRequestContentType sets the accepted content types for the engine.
 // By default, the accepted content types is */*.
 func WithRequestContentType(consumes ...string) func(*Engine) {
-	return func(e *Engine) { e.acceptedContentTypes = consumes }
+	return func(e *Engine) { e.requestContentTypes = consumes }
 }
 
 func WithOpenAPIConfig(config OpenAPIConfig) func(*Engine) {

--- a/engine_test.go
+++ b/engine_test.go
@@ -43,13 +43,13 @@ func TestWithErrorHandler(t *testing.T) {
 func TestWithRequestContentType(t *testing.T) {
 	t.Run("base", func(t *testing.T) {
 		e := NewEngine()
-		require.Nil(t, e.acceptedContentTypes)
+		require.Nil(t, e.requestContentTypes)
 	})
 
 	t.Run("input", func(t *testing.T) {
 		arr := []string{"application/json", "application/xml"}
 		e := NewEngine(WithRequestContentType("application/json", "application/xml"))
-		require.ElementsMatch(t, arr, e.acceptedContentTypes)
+		require.ElementsMatch(t, arr, e.requestContentTypes)
 	})
 
 	t.Run("ensure applied to route", func(t *testing.T) {

--- a/openapi.go
+++ b/openapi.go
@@ -187,7 +187,7 @@ func RegisterOpenAPIOperation[T, B any](openapi *OpenAPI, route Route[T, B]) (*o
 		bodyTag := SchemaTagFromType(openapi, *new(B))
 
 		if bodyTag.Name != "unknown-interface" {
-			requestBody := newRequestBody[B](bodyTag, route.AcceptedContentTypes)
+			requestBody := newRequestBody[B](bodyTag, route.RequestContentTypes)
 
 			// add request body to operation
 			route.Operation.RequestBody = &openapi3.RequestBodyRef{

--- a/option.go
+++ b/option.go
@@ -360,7 +360,7 @@ func OptionAddResponse(code int, description string, response Response) func(*Ba
 // This will override any options set at the server level.
 func OptionRequestContentType(consumes ...string) func(*BaseRoute) {
 	return func(r *BaseRoute) {
-		r.AcceptedContentTypes = consumes
+		r.RequestContentTypes = consumes
 	}
 }
 

--- a/option_test.go
+++ b/option_test.go
@@ -340,8 +340,8 @@ func TestRequestContentType(t *testing.T) {
 		s.Mux.ServeHTTP(w, r)
 
 		require.Equal(t, "{\"message\":\"hello world\"}\n", w.Body.String())
-		require.Len(t, route.AcceptedContentTypes, 1)
-		require.Equal(t, "application/json", route.AcceptedContentTypes[0])
+		require.Len(t, route.RequestContentTypes, 1)
+		require.Equal(t, "application/json", route.RequestContentTypes[0])
 	})
 
 	t.Run("base", func(t *testing.T) {

--- a/route.go
+++ b/route.go
@@ -22,13 +22,13 @@ type Route[ResponseBody any, RequestBody any] struct {
 
 func NewBaseRoute(method, path string, handler any, e *Engine, options ...func(*BaseRoute)) BaseRoute {
 	baseRoute := BaseRoute{
-		Method:               method,
-		Path:                 path,
-		Params:               make(map[string]OpenAPIParam),
-		FullName:             FuncName(handler),
-		Operation:            openapi3.NewOperation(),
-		OpenAPI:              e.OpenAPI,
-		AcceptedContentTypes: e.acceptedContentTypes,
+		Method:              method,
+		Path:                path,
+		Params:              make(map[string]OpenAPIParam),
+		FullName:            FuncName(handler),
+		Operation:           openapi3.NewOperation(),
+		OpenAPI:             e.OpenAPI,
+		RequestContentTypes: e.requestContentTypes,
 	}
 
 	for _, o := range options {
@@ -62,7 +62,7 @@ type BaseRoute struct {
 	FullName string
 
 	// Content types accepted for the request body. If nil, all content types (*/*) are accepted.
-	AcceptedContentTypes []string
+	RequestContentTypes []string
 
 	Middlewares []func(http.Handler) http.Handler
 


### PR DESCRIPTION
Per @ccoVeille here https://github.com/go-fuego/fuego/pull/333#discussion_r1906016234

The naming here doesn't line up. I decided to follow the naming of fixed field `content` described here: https://spec.openapis.org/oas/v3.1.0.html#fixed-fields-10.