### PR TITLE
chore: test Flow for edge cases cause by misconfigs

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -24,17 +24,17 @@ type ErrorWithDetail interface {
 // HTTPError is the error response used by the serialization part of the framework.
 type HTTPError struct {
 	// Developer readable error message. Not shown to the user to avoid security leaks.
-	Err error `json:"-" xml:"-"`
+	Err error `json:"-" xml:"-" yaml:"-"`
 	// URL of the error type. Can be used to lookup the error in a documentation
-	Type string `json:"type,omitempty" xml:"type,omitempty" description:"URL of the error type. Can be used to lookup the error in a documentation"`
+	Type string `json:"type,omitempty" xml:"type,omitempty" yaml:"type,omitempty" description:"URL of the error type. Can be used to lookup the error in a documentation"`
 	// Short title of the error
-	Title string `json:"title,omitempty" xml:"title,omitempty" description:"Short title of the error"`
-	// Human readable error message
-	Detail   string      `json:"detail,omitempty" xml:"detail,omitempty" description:"Human readable error message"`
-	Instance string      `json:"instance,omitempty" xml:"instance,omitempty"`
-	Errors   []ErrorItem `json:"errors,omitempty" xml:"errors,omitempty"`
+	Title string `json:"title,omitempty" xml:"title,omitempty" yaml:"title,omitempty" description:"Short title of the error"`
 	// HTTP status code. If using a different type than [HTTPError], for example [BadRequestError], this will be automatically overridden after Fuego error handling.
-	Status int `json:"status,omitempty" xml:"status,omitempty" description:"HTTP status code" example:"403"`
+	Status int `json:"status,omitempty" xml:"status,omitempty" yaml:"status,omitempty" description:"HTTP status code" example:"403"`
+	// Human readable error message
+	Detail   string      `json:"detail,omitempty" xml:"detail,omitempty" yaml:"detail,omitempty" description:"Human readable error message"`
+	Instance string      `json:"instance,omitempty" xml:"instance,omitempty" yaml:"instance,omitempty"`
+	Errors   []ErrorItem `json:"errors,omitempty" xml:"errors,omitempty" yaml:"errors,omitempty"`
 }
 
 type ErrorItem struct {

--- a/errors.go
+++ b/errors.go
@@ -44,15 +44,22 @@ type ErrorItem struct {
 }
 
 func (e HTTPError) Error() string {
-	title := e.Title
 	code := e.StatusCode()
+	title := e.Title
 	if title == "" {
 		title = http.StatusText(code)
 		if title == "" {
 			title = "HTTP Error"
 		}
 	}
-	return fmt.Sprintf("%d %s: %s", code, title, e.DetailMsg())
+	msg := fmt.Sprintf("%d %s", code, title)
+
+	detail := e.DetailMsg()
+	if detail == "" {
+		return msg
+	}
+
+	return fmt.Sprintf("%s: %s", msg, e.Detail)
 }
 
 func (e HTTPError) StatusCode() int {

--- a/serialization.go
+++ b/serialization.go
@@ -58,7 +58,11 @@ func transformOut[T any](ctx context.Context, ans T) (T, error) {
 
 	_, ok := any(ans).(OutTransformer)
 	if ok {
-		return ans, errors.New("OutTransformer must be implemented by a POINTER RECEIVER. Please read the [OutTransformer] documentation")
+		err := errors.New("OutTransformer must be implemented by a POINTER RECEIVER. Please read the [OutTransformer] documentation")
+		slog.Warn(err.Error())
+		return ans, InternalServerError{
+			Err: err,
+		}
 	}
 
 	outTransformer, ok := any(&ans).(OutTransformer)

--- a/serialization.go
+++ b/serialization.go
@@ -148,7 +148,7 @@ func SendYAMLError(w http.ResponseWriter, _ *http.Request, err error) {
 	}
 
 	w.WriteHeader(status)
-	_ = SendYAML(w, nil, err.Error())
+	_ = SendYAML(w, nil, err)
 }
 
 // SendJSON sends a JSON response.

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -351,14 +351,32 @@ func TestSendYAMLError(t *testing.T) {
 
 		require.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
 		require.Equal(t, "application/x-yaml", w.Header().Get("Content-Type"))
-		require.Equal(t, "Hello World\n", w.Body.String())
+		require.Equal(t, crlf(`{}`), w.Body.String())
 	})
 	t.Run("error with status", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		SendYAMLError(w, nil, BadRequestError{Err: errors.New("Hello World")})
 		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		require.Equal(t, "application/x-yaml", w.Header().Get("Content-Type"))
-		require.Equal(t, "Hello World\n", w.Body.String())
+		require.Equal(t, crlf(`{}`), w.Body.String())
+	})
+	t.Run("error with status and detail", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		SendYAMLError(w, nil, BadRequestError{Err: errors.New("Hello World"), Detail: "World, Hello"})
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		require.Equal(t, "application/x-yaml", w.Header().Get("Content-Type"))
+		require.Equal(t, crlf(`detail: World, Hello`), w.Body.String())
+	})
+	t.Run("error with multiple fields", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		SendYAMLError(w, nil, BadRequestError{
+			Err:    errors.New("Hello World"),
+			Detail: "World, Hello",
+			Title:  "Error: Hello, World",
+		})
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		require.Equal(t, "application/x-yaml", w.Header().Get("Content-Type"))
+		require.Equal(t, crlf("title: 'Error: Hello, World'\ndetail: World, Hello"), w.Body.String())
 	})
 }
 

--- a/serve_test.go
+++ b/serve_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,10 +45,26 @@ func (t *testOutTransformer) OutTransform(ctx context.Context) error {
 	return nil
 }
 
+type testOutTransformerOnNotReceiver struct {
+	Name     string `json:"name"`
+	Password string `json:"ans"`
+}
+
+func (t testOutTransformerOnNotReceiver) OutTransform(ctx context.Context) error {
+	t.Name = "M. " + t.Name
+	t.Password = "redacted"
+	return nil
+}
+
 var _ OutTransformer = &testOutTransformer{}
+var _ OutTransformer = &testOutTransformerOnNotReceiver{}
 
 func testControllerWithOutTransformer(c ContextNoBody) (testOutTransformer, error) {
 	return testOutTransformer{Name: "John"}, nil
+}
+
+func testControllerWithOutTransformerOnValueReceiver(c ContextNoBody) (testOutTransformerOnNotReceiver, error) {
+	return testOutTransformerOnNotReceiver{Name: "John"}, nil
 }
 
 func testControllerWithOutTransformerStar(c ContextNoBody) (*testOutTransformer, error) {
@@ -596,4 +613,40 @@ func newTLSTestHelper() (*tlsTestHelper, error) {
 	}
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privateKeyBytes})
 	return &tlsTestHelper{cert: certPEM, key: keyPEM}, nil
+}
+
+func TestFlow(t *testing.T) {
+	newTestCtx := func(w *httptest.ResponseRecorder) *netHttpContext[any] {
+		return NewNetHTTPContext[any](
+			BaseRoute{},
+			w,
+			httptest.NewRequest("GET", "/", nil),
+			readOptions{},
+		)
+	}
+
+	t.Run("base", func(t *testing.T) {
+		e := NewEngine()
+		w := httptest.NewRecorder()
+		ctx := newTestCtx(w)
+		Flow(e, ctx, testController)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, crlf(`{"ans":"Hello World"}`), w.Body.String())
+	})
+	t.Run("with nil return in ErrorHandler", func(t *testing.T) {
+		e := NewEngine(WithErrorHandler(func(err error) error { return nil }))
+		w := httptest.NewRecorder()
+		ctx := newTestCtx(w)
+		Flow(e, ctx, testControllerWithError)
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Equal(t, crlf(`null`), w.Body.String())
+	})
+	t.Run("transformOut error on value receiver", func(t *testing.T) {
+		e := NewEngine()
+		w := httptest.NewRecorder()
+		ctx := newTestCtx(w)
+		Flow(e, ctx, testControllerWithOutTransformerOnValueReceiver)
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Equal(t, crlf(`{}`), w.Body.String())
+	})
 }

--- a/serve_test.go
+++ b/serve_test.go
@@ -662,7 +662,7 @@ func TestFlow(t *testing.T) {
 			},
 			{
 				accept:           "application/x-yaml",
-				expectedResponse: crlf("500 Internal Server Error"),
+				expectedResponse: crlf("title: Internal Server Error\nstatus: 500"),
 			},
 			{
 				accept:           "text/plain",


### PR DESCRIPTION
Per #322

The following is to test provide a bit easier of test bed for testing edge cases do to server misconfigs or poor user input. The test here will pass, but they bring up some questions:

1. When ErrorHandler is overridden there is a possibility it can return `nil` causing golang encode to eventually land on `null` (I will probably expand this to more return types but wanted to get the conversation going). What should we do here? Is the user setting the return type to nil to say it's fine and we should really respond with like `NoContent` or is just saying 500 with empty/null response good enough. I personally think if the user is setting their error to nil they're doing something on purpose 🤷 
2. In the case of transformOut error when it's receiver is a value and not a pointer. We throw errors.New(""). ErrorStrings are not marshalable. In this case I think we should wrap this error with `fuego.InternalServerError` since transform is supported only on structs with the implementation we can assume a json/xml/x-yaml response is fine depending on the user request. 