### PR TITLE
fix: SendYAMLError to properly pass the entire error when sending

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -24,17 +24,17 @@ type ErrorWithDetail interface {
 // HTTPError is the error response used by the serialization part of the framework.
 type HTTPError struct {
 	// Developer readable error message. Not shown to the user to avoid security leaks.
-	Err error `json:"-" xml:"-"`
+	Err error `json:"-" xml:"-" yaml:"-"`
 	// URL of the error type. Can be used to lookup the error in a documentation
-	Type string `json:"type,omitempty" xml:"type,omitempty" description:"URL of the error type. Can be used to lookup the error in a documentation"`
+	Type string `json:"type,omitempty" xml:"type,omitempty" yaml:"type,omitempty" description:"URL of the error type. Can be used to lookup the error in a documentation"`
 	// Short title of the error
-	Title string `json:"title,omitempty" xml:"title,omitempty" description:"Short title of the error"`
-	// Human readable error message
-	Detail   string      `json:"detail,omitempty" xml:"detail,omitempty" description:"Human readable error message"`
-	Instance string      `json:"instance,omitempty" xml:"instance,omitempty"`
-	Errors   []ErrorItem `json:"errors,omitempty" xml:"errors,omitempty"`
+	Title string `json:"title,omitempty" xml:"title,omitempty" yaml:"title,omitempty" description:"Short title of the error"`
 	// HTTP status code. If using a different type than [HTTPError], for example [BadRequestError], this will be automatically overridden after Fuego error handling.
-	Status int `json:"status,omitempty" xml:"status,omitempty" description:"HTTP status code" example:"403"`
+	Status int `json:"status,omitempty" xml:"status,omitempty" yaml:"status,omitempty" description:"HTTP status code" example:"403"`
+	// Human readable error message
+	Detail   string      `json:"detail,omitempty" xml:"detail,omitempty" yaml:"detail,omitempty" description:"Human readable error message"`
+	Instance string      `json:"instance,omitempty" xml:"instance,omitempty" yaml:"instance,omitempty"`
+	Errors   []ErrorItem `json:"errors,omitempty" xml:"errors,omitempty" yaml:"errors,omitempty"`
 }
 
 type ErrorItem struct {

--- a/serialization.go
+++ b/serialization.go
@@ -148,7 +148,7 @@ func SendYAMLError(w http.ResponseWriter, _ *http.Request, err error) {
 	}
 
 	w.WriteHeader(status)
-	_ = SendYAML(w, nil, err.Error())
+	_ = SendYAML(w, nil, err)
 }
 
 // SendJSON sends a JSON response.

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -351,14 +351,32 @@ func TestSendYAMLError(t *testing.T) {
 
 		require.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
 		require.Equal(t, "application/x-yaml", w.Header().Get("Content-Type"))
-		require.Equal(t, "Hello World\n", w.Body.String())
+		require.Equal(t, crlf(`{}`), w.Body.String())
 	})
 	t.Run("error with status", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		SendYAMLError(w, nil, BadRequestError{Err: errors.New("Hello World")})
 		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		require.Equal(t, "application/x-yaml", w.Header().Get("Content-Type"))
-		require.Equal(t, "Hello World\n", w.Body.String())
+		require.Equal(t, crlf(`{}`), w.Body.String())
+	})
+	t.Run("error with status and detail", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		SendYAMLError(w, nil, BadRequestError{Err: errors.New("Hello World"), Detail: "World, Hello"})
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		require.Equal(t, "application/x-yaml", w.Header().Get("Content-Type"))
+		require.Equal(t, crlf(`detail: World, Hello`), w.Body.String())
+	})
+	t.Run("error with multiple fields", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		SendYAMLError(w, nil, BadRequestError{
+			Err:    errors.New("Hello World"),
+			Detail: "World, Hello",
+			Title:  "Error: Hello, World",
+		})
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		require.Equal(t, "application/x-yaml", w.Header().Get("Content-Type"))
+		require.Equal(t, crlf("title: 'Error: Hello, World'\ndetail: World, Hello"), w.Body.String())
 	})
 }
 

--- a/serve_test.go
+++ b/serve_test.go
@@ -662,7 +662,7 @@ func TestFlow(t *testing.T) {
 			},
 			{
 				accept:           "application/x-yaml",
-				expectedResponse: crlf("500 Internal Server Error"),
+				expectedResponse: crlf("title: Internal Server Error\nstatus: 500"),
 			},
 			{
 				accept:           "text/plain",


### PR DESCRIPTION
closes #339

Based on #336 for readability. 