### PR TITLE
WIP: OpenAPIServable

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -100,11 +100,11 @@ func WithOpenAPIConfig(config OpenAPIConfig) func(*Engine) {
 		e.OpenAPIConfig.DisableSwaggerUI = config.DisableSwaggerUI
 
 		if !validateSpecURL(e.OpenAPIConfig.SpecURL) {
-			slog.Error("Error serving openapi json spec. Value of 's.OpenAPIServerConfig.SpecURL' option is not valid", "url", e.OpenAPIConfig.SpecURL)
+			slog.Error("Error serving OpenAPI JSON spec. Value of 's.OpenAPIServerConfig.SpecURL' option is not valid", "url", e.OpenAPIConfig.SpecURL)
 			return
 		}
 		if !validateSwaggerURL(e.OpenAPIConfig.SwaggerURL) {
-			slog.Error("Error serving swagger ui. Value of 's.OpenAPIServerConfig.SwaggerURL' option is not valid", "url", e.OpenAPIConfig.SwaggerURL)
+			slog.Error("Error serving Swagger UI. Value of 's.OpenAPIServerConfig.SwaggerURL' option is not valid", "url", e.OpenAPIConfig.SwaggerURL)
 			return
 		}
 	}

--- a/engine.go
+++ b/engine.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // NewEngine creates a new Engine with the given options.
@@ -53,10 +56,21 @@ type OpenAPIConfig struct {
 	DisableLocalSave bool
 	// Pretty prints the OpenAPI spec with proper JSON indentation
 	PrettyFormatJSON bool
+	// URL to serve the OpenAPI JSON spec
+	SpecURL string
+	// Handler to serve the OpenAPI UI from spec URL
+	UIHandler func(specURL string) http.Handler
+	// URL to serve the swagger UI
+	SwaggerURL string
+	// If true, the server will not serve the Swagger UI
+	DisableSwaggerUI bool
 }
 
 var defaultOpenAPIConfig = OpenAPIConfig{
 	JSONFilePath: "doc/openapi.json",
+	SpecURL:      "/swagger/openapi.json",
+	SwaggerURL:   "/swagger",
+	UIHandler:    DefaultOpenAPIHandler,
 }
 
 // WithRequestContentType sets the accepted content types for the engine.
@@ -70,10 +84,29 @@ func WithOpenAPIConfig(config OpenAPIConfig) func(*Engine) {
 		if config.JSONFilePath != "" {
 			e.OpenAPIConfig.JSONFilePath = config.JSONFilePath
 		}
+		if config.SpecURL != "" {
+			e.OpenAPIConfig.SpecURL = config.SpecURL
+		}
+		if config.SwaggerURL != "" {
+			e.OpenAPIConfig.SwaggerURL = config.SwaggerURL
+		}
+		if config.UIHandler != nil {
+			e.OpenAPIConfig.UIHandler = config.UIHandler
+		}
 
 		e.OpenAPIConfig.Disabled = config.Disabled
 		e.OpenAPIConfig.DisableLocalSave = config.DisableLocalSave
 		e.OpenAPIConfig.PrettyFormatJSON = config.PrettyFormatJSON
+		e.OpenAPIConfig.DisableSwaggerUI = config.DisableSwaggerUI
+
+		if !validateSpecURL(e.OpenAPIConfig.SpecURL) {
+			slog.Error("Error serving openapi json spec. Value of 's.OpenAPIServerConfig.SpecURL' option is not valid", "url", e.OpenAPIConfig.SpecURL)
+			return
+		}
+		if !validateSwaggerURL(e.OpenAPIConfig.SwaggerURL) {
+			slog.Error("Error serving swagger ui. Value of 's.OpenAPIServerConfig.SwaggerURL' option is not valid", "url", e.OpenAPIConfig.SwaggerURL)
+			return
+		}
 	}
 }
 
@@ -95,8 +128,14 @@ func DisableErrorHandler() func(*Engine) {
 	}
 }
 
+func (e *Engine) SpecHandler() func(c ContextNoBody) (openapi3.T, error) {
+	return func(c ContextNoBody) (openapi3.T, error) {
+		return *e.OpenAPI.Description(), nil
+	}
+}
+
 // OutputOpenAPISpec takes the OpenAPI spec and outputs it to a JSON file
-func (e *Engine) OutputOpenAPISpec() []byte {
+func (e *Engine) OutputOpenAPISpec() *openapi3.T {
 	e.OpenAPI.computeTags()
 
 	// Validate
@@ -117,7 +156,7 @@ func (e *Engine) OutputOpenAPISpec() []byte {
 			slog.Error("Error saving spec to local path", "error", err, "path", e.OpenAPIConfig.JSONFilePath)
 		}
 	}
-	return jsonSpec
+	return e.OpenAPI.Description()
 }
 
 func (e *Engine) saveOpenAPIToFile(jsonSpecLocalPath string, jsonSpec []byte) error {

--- a/examples/gin-compat/adaptor_test.go
+++ b/examples/gin-compat/adaptor_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestFuegoGin(t *testing.T) {
-	a := server()
+	e, _ := server()
 
 	t.Run("simply test gin", func(t *testing.T) {
 		r := httptest.NewRequest("GET", "/gin", nil)
 		w := httptest.NewRecorder()
 
-		a.ServeHTTP(w, r)
+		e.ServeHTTP(w, r)
 
 		require.Equal(t, 200, w.Code)
 	})
@@ -24,7 +24,7 @@ func TestFuegoGin(t *testing.T) {
 		r := httptest.NewRequest("GET", "/fuego", nil)
 		w := httptest.NewRecorder()
 
-		a.ServeHTTP(w, r)
+		e.ServeHTTP(w, r)
 
 		require.Equal(t, http.StatusOK, w.Code)
 		require.JSONEq(t, `{"message":"Hello"}`, w.Body.String())

--- a/examples/gin-compat/adaptor_test.go
+++ b/examples/gin-compat/adaptor_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestFuegoGin(t *testing.T) {
-	e, _ := server()
+	a := server()
 
 	t.Run("simply test gin", func(t *testing.T) {
 		r := httptest.NewRequest("GET", "/gin", nil)
 		w := httptest.NewRecorder()
 
-		e.ServeHTTP(w, r)
+		a.ServeHTTP(w, r)
 
 		require.Equal(t, 200, w.Code)
 	})
@@ -24,7 +24,7 @@ func TestFuegoGin(t *testing.T) {
 		r := httptest.NewRequest("GET", "/fuego", nil)
 		w := httptest.NewRecorder()
 
-		e.ServeHTTP(w, r)
+		a.ServeHTTP(w, r)
 
 		require.Equal(t, http.StatusOK, w.Code)
 		require.JSONEq(t, `{"message":"Hello"}`, w.Body.String())

--- a/examples/gin-compat/handlers.go
+++ b/examples/gin-compat/handlers.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
 
@@ -37,17 +36,4 @@ func fuegoControllerPost(c fuego.ContextWithBody[HelloRequest]) (*HelloResponse,
 	return &HelloResponse{
 		Message: fmt.Sprintf("Hello %s, %s", body.Word, name),
 	}, nil
-}
-
-func serveOpenApiJSONDescription(s *fuego.OpenAPI) func(ctx *gin.Context) {
-	return func(ctx *gin.Context) {
-		ctx.JSON(http.StatusOK, s.Description())
-	}
-}
-
-func DefaultOpenAPIHandler(specURL string) gin.HandlerFunc {
-	return func(ctx *gin.Context) {
-		ctx.Header("Content-Type", "text/html; charset=utf-8")
-		ctx.String(200, fuego.DefaultOpenAPIHTML(specURL))
-	}
 }

--- a/examples/gin-compat/main.go
+++ b/examples/gin-compat/main.go
@@ -25,17 +25,17 @@ type HelloResponse struct {
 }
 
 func main() {
-	e, _ := server()
+	a := server()
 
 	fmt.Println("OpenAPI at at http://localhost:8980/swagger ✅")
 
-	err := e.Run(":8980")
+	err := a.Run(":8980")
 	if err != nil {
 		panic(err)
 	}
 }
 
-func server() (*gin.Engine, *fuego.OpenAPI) {
+func server() *fuegogin.Adaptor {
 	ginRouter := gin.Default()
 	engine := fuego.NewEngine()
 
@@ -81,10 +81,7 @@ func server() (*gin.Engine, *fuego.OpenAPI) {
 	)
 
 	// Serve the OpenAPI spec
-	ginRouter.GET("/openapi.json", serveOpenApiJSONDescription(engine.OpenAPI))
-	ginRouter.GET("/swagger", DefaultOpenAPIHandler("/openapi.json"))
-
-	return ginRouter, engine.OpenAPI
+	return fuegogin.NewAdaptor(ginRouter, engine)
 }
 
 func (h *HelloRequest) InTransform(ctx context.Context) error {

--- a/examples/gin-compat/main.go
+++ b/examples/gin-compat/main.go
@@ -25,17 +25,17 @@ type HelloResponse struct {
 }
 
 func main() {
-	a := server()
+	e, _ := server()
 
 	fmt.Println("OpenAPI at at http://localhost:8980/swagger ✅")
 
-	err := a.Run(":8980")
+	err := e.Run(":8980")
 	if err != nil {
 		panic(err)
 	}
 }
 
-func server() *fuegogin.Adaptor {
+func server() (*gin.Engine, *fuego.OpenAPI) {
 	ginRouter := gin.Default()
 	engine := fuego.NewEngine()
 
@@ -80,8 +80,10 @@ func server() *fuegogin.Adaptor {
 		option.Tags("Fuego"),
 	)
 
+	engine.RegisterOpenAPIRoutes(&fuegogin.OpenAPIHandler{ginRouter})
+
 	// Serve the OpenAPI spec
-	return fuegogin.NewAdaptor(ginRouter, engine)
+	return ginRouter, engine.OpenAPI
 }
 
 func (h *HelloRequest) InTransform(ctx context.Context) error {

--- a/examples/petstore/lib/server_test.go
+++ b/examples/petstore/lib/server_test.go
@@ -22,6 +22,7 @@ func TestPetstoreOpenAPIGeneration(t *testing.T) {
 		),
 	)
 
+	fuego.RegisterOpenAPIRoutes(server.Engine, server)
 	server.OutputOpenAPISpec()
 	err := server.OpenAPI.Description().Validate(context.Background())
 	require.NoError(t, err)

--- a/examples/petstore/lib/server_test.go
+++ b/examples/petstore/lib/server_test.go
@@ -22,7 +22,7 @@ func TestPetstoreOpenAPIGeneration(t *testing.T) {
 		),
 	)
 
-	fuego.RegisterOpenAPIRoutes(server.Engine, server)
+	server.Engine.RegisterOpenAPIRoutes(server)
 	server.OutputOpenAPISpec()
 	err := server.OpenAPI.Description().Validate(context.Background())
 	require.NoError(t, err)

--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -1556,12 +1556,6 @@
 			}
 		}
 	},
-	"servers": [
-		{
-			"description": "local server",
-			"url": "http://localhost:9999"
-		}
-	],
 	"tags": [
 		{
 			"name": "my-tag"

--- a/extra/fuegogin/adaptor.go
+++ b/extra/fuegogin/adaptor.go
@@ -9,27 +9,20 @@ import (
 	"github.com/go-fuego/fuego/internal"
 )
 
-type Adaptor struct {
-	fuegoEngine *fuego.Engine
+type OpenAPIHandler struct {
 	*gin.Engine
 }
 
-func NewAdaptor(g *gin.Engine, e *fuego.Engine) *Adaptor {
-	a := &Adaptor{Engine: g, fuegoEngine: e}
-	fuego.RegisterOpenAPIRoutes(e, a)
-	return a
+func (o *OpenAPIHandler) SpecHandler(e *fuego.Engine) {
+	Get(e, o, e.OpenAPIConfig.SpecURL, e.SpecHandler(), fuego.OptionHide())
 }
 
-func (a *Adaptor) SpecHandler() {
-	Get(a.fuegoEngine, a, a.fuegoEngine.OpenAPIConfig.SpecURL, a.fuegoEngine.SpecHandler(), fuego.OptionHide())
-}
-
-func (a *Adaptor) UIHandler() {
+func (o *OpenAPIHandler) UIHandler(e *fuego.Engine) {
 	GetGin(
-		a.fuegoEngine,
-		a,
-		a.fuegoEngine.OpenAPIConfig.SwaggerURL+"/",
-		gin.WrapH(a.fuegoEngine.OpenAPIConfig.UIHandler(a.fuegoEngine.OpenAPIConfig.SpecURL)),
+		e,
+		o,
+		e.OpenAPIConfig.SwaggerURL+"/",
+		gin.WrapH(e.OpenAPIConfig.UIHandler(e.OpenAPIConfig.SpecURL)),
 		fuego.OptionHide(),
 	)
 }

--- a/extra/fuegogin/adaptor.go
+++ b/extra/fuegogin/adaptor.go
@@ -10,17 +10,17 @@ import (
 )
 
 type OpenAPIHandler struct {
-	*gin.Engine
+	GinEngine *gin.Engine
 }
 
 func (o *OpenAPIHandler) SpecHandler(e *fuego.Engine) {
-	Get(e, o, e.OpenAPIConfig.SpecURL, e.SpecHandler(), fuego.OptionHide())
+	Get(e, o.GinEngine, e.OpenAPIConfig.SpecURL, e.SpecHandler(), fuego.OptionHide())
 }
 
 func (o *OpenAPIHandler) UIHandler(e *fuego.Engine) {
 	GetGin(
 		e,
-		o,
+		o.GinEngine,
 		e.OpenAPIConfig.SwaggerURL+"/",
 		gin.WrapH(e.OpenAPIConfig.UIHandler(e.OpenAPIConfig.SpecURL)),
 		fuego.OptionHide(),

--- a/extra/fuegogin/adaptor.go
+++ b/extra/fuegogin/adaptor.go
@@ -9,6 +9,31 @@ import (
 	"github.com/go-fuego/fuego/internal"
 )
 
+type Adaptor struct {
+	fuegoEngine *fuego.Engine
+	*gin.Engine
+}
+
+func NewAdaptor(g *gin.Engine, e *fuego.Engine) *Adaptor {
+	a := &Adaptor{Engine: g, fuegoEngine: e}
+	fuego.RegisterOpenAPIRoutes(e, a)
+	return a
+}
+
+func (a *Adaptor) SpecHandler() {
+	Get(a.fuegoEngine, a, a.fuegoEngine.OpenAPIConfig.SpecURL, a.fuegoEngine.SpecHandler(), fuego.OptionHide())
+}
+
+func (a *Adaptor) UIHandler() {
+	GetGin(
+		a.fuegoEngine,
+		a,
+		a.fuegoEngine.OpenAPIConfig.SwaggerURL+"/",
+		gin.WrapH(a.fuegoEngine.OpenAPIConfig.UIHandler(a.fuegoEngine.OpenAPIConfig.SpecURL)),
+		fuego.OptionHide(),
+	)
+}
+
 func GetGin(engine *fuego.Engine, ginRouter gin.IRouter, path string, handler gin.HandlerFunc, options ...func(*fuego.BaseRoute)) *fuego.Route[any, any] {
 	return handleGin(engine, ginRouter, http.MethodGet, path, handler, options...)
 }

--- a/openapi.go
+++ b/openapi.go
@@ -81,20 +81,20 @@ func NewOpenApiSpec() openapi3.T {
 }
 
 type OpenAPIServable interface {
-	SpecHandler()
-	UIHandler()
+	SpecHandler(e *Engine)
+	UIHandler(e *Engine)
 }
 
-func RegisterOpenAPIRoutes(e *Engine, o OpenAPIServable) {
+func (e *Engine) RegisterOpenAPIRoutes(o OpenAPIServable) {
 	if e.OpenAPIConfig.Disabled {
 		return
 	}
-	o.SpecHandler()
+	o.SpecHandler(e)
 
 	if e.OpenAPIConfig.DisableSwaggerUI {
 		return
 	}
-	o.UIHandler()
+	o.UIHandler(e)
 }
 
 // Hide prevents the routes in this server or group from being included in the OpenAPI spec.

--- a/openapi_handler.go
+++ b/openapi_handler.go
@@ -1,8 +1,6 @@
 package fuego
 
-import (
-	"net/http"
-)
+import "net/http"
 
 func DefaultOpenAPIHandler(specURL string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/openapi_handler_test.go
+++ b/openapi_handler_test.go
@@ -21,7 +21,7 @@ func TestUIHandler(t *testing.T) {
 	t.Run("works with DefaultOpenAPIHandler", func(t *testing.T) {
 		s := NewServer()
 
-		RegisterOpenAPIRoutes(s.Engine, s)
+		s.Engine.RegisterOpenAPIRoutes(s)
 
 		require.NotNil(t, s.OpenAPIConfig.UIHandler)
 
@@ -45,7 +45,7 @@ func TestUIHandler(t *testing.T) {
 				}),
 			),
 		)
-		RegisterOpenAPIRoutes(s.Engine, s)
+		s.Engine.RegisterOpenAPIRoutes(s)
 
 		require.NotNil(t, s.OpenAPIConfig.UIHandler)
 
@@ -68,7 +68,7 @@ func TestUIHandler(t *testing.T) {
 			),
 		)
 
-		RegisterOpenAPIRoutes(s.Engine, s)
+		s.Engine.RegisterOpenAPIRoutes(s)
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "/swagger/index.html", nil)

--- a/openapi_handler_test.go
+++ b/openapi_handler_test.go
@@ -21,9 +21,9 @@ func TestUIHandler(t *testing.T) {
 	t.Run("works with DefaultOpenAPIHandler", func(t *testing.T) {
 		s := NewServer()
 
-		s.OutputOpenAPISpec()
+		RegisterOpenAPIRoutes(s.Engine, s)
 
-		require.NotNil(t, s.OpenAPIServerConfig.UIHandler)
+		require.NotNil(t, s.OpenAPIConfig.UIHandler)
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "/swagger/index.html", nil)
@@ -37,15 +37,17 @@ func TestUIHandler(t *testing.T) {
 
 	t.Run("wrap DefaultOpenAPIHandler behind a middleware", func(t *testing.T) {
 		s := NewServer(
-			WithOpenAPIServerConfig(OpenAPIServerConfig{
-				UIHandler: func(specURL string) http.Handler {
-					return dummyMiddleware(DefaultOpenAPIHandler(specURL))
-				},
-			}),
+			WithEngineOptions(
+				WithOpenAPIConfig(OpenAPIConfig{
+					UIHandler: func(specURL string) http.Handler {
+						return dummyMiddleware(DefaultOpenAPIHandler(specURL))
+					},
+				}),
+			),
 		)
-		s.OutputOpenAPISpec()
+		RegisterOpenAPIRoutes(s.Engine, s)
 
-		require.NotNil(t, s.OpenAPIServerConfig.UIHandler)
+		require.NotNil(t, s.OpenAPIConfig.UIHandler)
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "/swagger/index.html", nil)
@@ -59,12 +61,14 @@ func TestUIHandler(t *testing.T) {
 
 	t.Run("disabling UI", func(t *testing.T) {
 		s := NewServer(
-			WithOpenAPIServerConfig(OpenAPIServerConfig{
-				DisableSwaggerUI: true,
-			}),
+			WithEngineOptions(
+				WithOpenAPIConfig(OpenAPIConfig{
+					DisableSwaggerUI: true,
+				}),
+			),
 		)
 
-		s.OutputOpenAPISpec()
+		RegisterOpenAPIRoutes(s.Engine, s)
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "/swagger/index.html", nil)

--- a/serve.go
+++ b/serve.go
@@ -43,7 +43,7 @@ func (s *Server) setup() error {
 		Description: "local server",
 	})
 	go s.OutputOpenAPISpec()
-	RegisterOpenAPIRoutes(s.Engine, s)
+	s.Engine.RegisterOpenAPIRoutes(s)
 	s.printStartupMessage()
 
 	s.Server.Handler = s.Mux

--- a/serve.go
+++ b/serve.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"reflect"
 	"time"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // Run starts the server.
@@ -36,7 +38,12 @@ func (s *Server) setup() error {
 	if err := s.setupDefaultListener(); err != nil {
 		return err
 	}
+	s.OpenAPI.Description().Servers = append(s.OpenAPI.Description().Servers, &openapi3.Server{
+		URL:         s.url(),
+		Description: "local server",
+	})
 	go s.OutputOpenAPISpec()
+	RegisterOpenAPIRoutes(s.Engine, s)
 	s.printStartupMessage()
 
 	s.Server.Handler = s.Mux

--- a/server.go
+++ b/server.go
@@ -142,13 +142,12 @@ func NewServer(options ...func(*Server)) *Server {
 	return s
 }
 
-// Registers the routes to serve the OpenAPI spec and Swagger UI.
-func (s *Server) SpecHandler() {
+func (s *Server) SpecHandler(_ *Engine) {
 	Get(s, s.OpenAPIConfig.SpecURL, s.Engine.SpecHandler(), OptionHide())
 	s.printOpenAPIMessage(fmt.Sprintf("JSON spec: %s%s", s.url(), s.OpenAPIConfig.SpecURL))
 }
 
-func (s *Server) UIHandler() {
+func (s *Server) UIHandler(_ *Engine) {
 	GetStd(s, s.OpenAPIConfig.SwaggerURL+"/", s.OpenAPIConfig.UIHandler(s.OpenAPIConfig.SpecURL).ServeHTTP, OptionHide())
 	s.printOpenAPIMessage(fmt.Sprintf("OpenAPI UI: %s%s/index.html", s.url(), s.OpenAPIConfig.SwaggerURL))
 }

--- a/server_test.go
+++ b/server_test.go
@@ -74,21 +74,19 @@ func TestWithXML(t *testing.T) {
 func TestWithOpenAPIConfig(t *testing.T) {
 	t.Run("with default values", func(t *testing.T) {
 		s := NewServer(
-			WithOpenAPIServerConfig(OpenAPIServerConfig{}),
+			WithEngineOptions(
+				WithOpenAPIConfig(OpenAPIConfig{}),
+			),
 		)
 
-		require.Equal(t, "/swagger", s.OpenAPIServerConfig.SwaggerURL)
-		require.Equal(t, "/swagger/openapi.json", s.OpenAPIServerConfig.SpecURL)
+		require.Equal(t, "/swagger", s.OpenAPIConfig.SwaggerURL)
+		require.Equal(t, "/swagger/openapi.json", s.OpenAPIConfig.SpecURL)
 		require.Equal(t, "doc/openapi.json", s.OpenAPIConfig.JSONFilePath)
 		require.False(t, s.OpenAPIConfig.PrettyFormatJSON)
 	})
 
 	t.Run("with custom values", func(t *testing.T) {
 		s := NewServer(
-			WithOpenAPIServerConfig(OpenAPIServerConfig{
-				SwaggerURL: "/api",
-				SpecURL:    "/api/openapi.json",
-			}),
 			WithEngineOptions(
 				WithOpenAPIConfig(
 					OpenAPIConfig{
@@ -96,12 +94,14 @@ func TestWithOpenAPIConfig(t *testing.T) {
 						DisableLocalSave: true,
 						PrettyFormatJSON: true,
 						Disabled:         true,
+						SwaggerURL:       "/api",
+						SpecURL:          "/api/openapi.json",
 					}),
 			),
 		)
 
-		require.Equal(t, "/api", s.OpenAPIServerConfig.SwaggerURL)
-		require.Equal(t, "/api/openapi.json", s.OpenAPIServerConfig.SpecURL)
+		require.Equal(t, "/api", s.OpenAPIConfig.SwaggerURL)
+		require.Equal(t, "/api/openapi.json", s.OpenAPIConfig.SpecURL)
 		require.Equal(t, "openapi.json", s.OpenAPIConfig.JSONFilePath)
 		require.True(t, s.Engine.OpenAPIConfig.Disabled)
 		require.True(t, s.OpenAPIConfig.DisableLocalSave)
@@ -111,26 +111,22 @@ func TestWithOpenAPIConfig(t *testing.T) {
 	t.Run("with invalid local path values", func(t *testing.T) {
 		t.Run("with invalid path", func(t *testing.T) {
 			NewServer(
-				WithOpenAPIServerConfig(OpenAPIServerConfig{
-					SwaggerURL: "p   i",
-					SpecURL:    "pi/op  enapi.json",
-				}),
 				WithEngineOptions(
 					WithOpenAPIConfig(OpenAPIConfig{
 						JSONFilePath: "path/to/jsonSpec",
+						SwaggerURL:   "p   i",
+						SpecURL:      "pi/op  enapi.json",
 					}),
 				),
 			)
 		})
 		t.Run("with invalid url", func(t *testing.T) {
 			NewServer(
-				WithOpenAPIServerConfig(OpenAPIServerConfig{
-					SpecURL:    "pi/op  enapi.json",
-					SwaggerURL: "p   i",
-				}),
 				WithEngineOptions(
 					WithOpenAPIConfig(OpenAPIConfig{
 						JSONFilePath: "path/to/jsonSpec.json",
+						SpecURL:      "pi/op  enapi.json",
+						SwaggerURL:   "p   i",
 					}),
 				),
 			)
@@ -138,13 +134,11 @@ func TestWithOpenAPIConfig(t *testing.T) {
 
 		t.Run("with invalid url", func(t *testing.T) {
 			NewServer(
-				WithOpenAPIServerConfig(OpenAPIServerConfig{
-					SpecURL:    "/api/openapi.json",
-					SwaggerURL: "invalid path",
-				}),
 				WithEngineOptions(
 					WithOpenAPIConfig(OpenAPIConfig{
 						JSONFilePath: "path/to/jsonSpec.json",
+						SpecURL:      "/api/openapi.json",
+						SwaggerURL:   "invalid path",
 					}),
 				),
 			)


### PR DESCRIPTION
Heavy WIP

Working through how this would work. 

Just wanted to get a initial outline on how we could do this. Feel free to discuss over top of this. I imagine we reach the point with our adaptors where we have something like `fuegogin.Adaptor.Run()`, in this case it would `engine.OutputOpenAPISpec`, `engine.RegisterOpenAPIRoutes`, and then start the gin server. Again everything is exposed and we can provide options maybe, but users can plug and play as they please. 

PS. Feel free to open PR against this or contribute directly 😄 