### PR TITLE
Fix return type in `echo` function to match expected string type

### DIFF
--- a/documentation/docs/guides/serialization.md
+++ b/documentation/docs/guides/serialization.md
@@ -47,7 +47,7 @@ func echo(c fuego.ContextWithBody[ReceivedType]) (string, error) {
 	// whether it's application/json, application/xml, application/x-www-form-urlencoded, etc.
 	received, err := c.Body()
 	if err != nil {
-		return ReceivedType{}, err
+		return "", err
 	}
 
 	return received.Message, nil


### PR DESCRIPTION
This pull request fixes the return type in the `echo` function to match the expected string type.