### PR TITLE
feat: Add basic integration tests with Hurl

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -1,0 +1,55 @@
+# Integration Tests for Fuego
+
+This directory contains integration tests for the Fuego framework using [Hurl](https://hurl.dev/).
+
+## Prerequisites
+
+- Go 1.21 or later
+- Hurl (install via `winget install Orange-OpenSource.Hurl` on Windows or `brew install hurl` on macOS)
+
+## Running Tests
+
+1. Start the Fuego server in one terminal:
+
+   ```bash
+   cd ../examples/basic
+   go run .
+   ```
+
+2. Run the tests in another terminal using:
+
+   Windows:
+
+   ```powershell
+   .\run_tests.ps1
+   ```
+
+   Unix/Linux/Git Bash:
+
+   ```bash
+   # First time only
+   chmod +x run_tests.sh
+
+   # Run tests
+   ./run_tests.sh
+   ```
+
+## Test Structure
+
+- `basic.hurl`: Tests basic functionality including:
+  - Successful POST request with JSON response
+  - Validation errors
+  - Header validation
+  - Standard GET endpoint
+
+## Adding New Tests
+
+1. Create a new `.hurl` file in this directory
+2. Add your test cases following the Hurl syntax
+3. Update the test runners if needed to include your new test file
+
+## Troubleshooting
+
+- If tests fail with connection errors, ensure no other process is using port 8088
+- If using the shell scripts, ensure they have the correct line endings for your OS
+- For Windows users, Git Bash is recommended when using the bash script

--- a/integration_tests/basic.hurl
+++ b/integration_tests/basic.hurl
@@ -1,0 +1,36 @@
+# Test the basic endpoints
+# Basic POST endpoint test with all required headers
+POST http://localhost:8088/
+Content-Type: application/json
+test: test
+{
+    "name": "John"
+}
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json"
+header "X-Hello" == "World"
+jsonpath "$.message" == "HELLO, JOHN"
+jsonpath "$.best" == "Fuego!"
+
+# Test validation error
+POST http://localhost:8088/
+Content-Type: application/json
+{
+    "name": ""
+}
+HTTP 400
+
+# Test header validation
+POST http://localhost:8088/
+Content-Type: application/json
+{
+    "name": "John"
+}
+HTTP 500
+
+# Test standard handler
+GET http://localhost:8088/std
+HTTP 200
+[Asserts]
+body == "Hello, World!" 

--- a/integration_tests/run_tests.ps1
+++ b/integration_tests/run_tests.ps1
@@ -1,0 +1,54 @@
+# Kill any existing process on port 8088
+$existingProcess = Get-NetTCPConnection -LocalPort 8088 -ErrorAction SilentlyContinue
+if ($existingProcess) {
+    Stop-Process -Id $existingProcess.OwningProcess -Force
+}
+
+# Start the server in background
+Push-Location examples\basic
+$server = Start-Process -FilePath "go" -ArgumentList "run", "main.go" -PassThru -WindowStyle Hidden
+
+# Function to cleanup
+function Cleanup {
+    Write-Host "Cleaning up..."
+    if ($server) {
+        Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
+    }
+    Pop-Location
+}
+
+# Setup cleanup on script exit
+trap {
+    Cleanup
+    break
+}
+
+# Wait for server to be ready
+Write-Host "Waiting for server to start..."
+$ready = $false
+for ($i = 1; $i -le 30; $i++) {
+    try {
+        $response = Invoke-WebRequest -Uri "http://localhost:8088/std" -UseBasicParsing -ErrorAction SilentlyContinue
+        if ($response.StatusCode -eq 200) {
+            Write-Host "Server is ready!"
+            $ready = $true
+            break
+        }
+    }
+    catch {
+        Start-Sleep -Seconds 1
+    }
+}
+
+if (-not $ready) {
+    Write-Host "Server failed to start within 30 seconds"
+    Cleanup
+    exit 1
+}
+
+# Run the tests
+Set-Location ..\..\integration_tests
+hurl --test basic.hurl
+
+# Cleanup
+Cleanup 

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Exit on error
+set -e
+
+# Kill any existing process on port 8088
+if command -v lsof >/dev/null 2>&1; then
+    # For Unix-like systems with lsof
+    kill $(lsof -t -i:8088) 2>/dev/null || true
+elif command -v netstat >/dev/null 2>&1; then
+    # For systems with netstat (including Git Bash on Windows)
+    pid=$(netstat -ano | grep "8088" | awk '{print $5}') && kill $pid 2>/dev/null || true
+fi
+
+# Function to cleanup
+cleanup() {
+    echo "Cleaning up..."
+    if [ -n "$SERVER_PID" ]; then
+        kill $SERVER_PID 2>/dev/null || true
+    fi
+    cd "$ORIGINAL_DIR"
+}
+
+# Store original directory
+ORIGINAL_DIR=$(pwd)
+
+# Setup cleanup on script exit
+trap cleanup EXIT
+
+# Start the server in background
+cd examples/basic
+go run main.go &
+SERVER_PID=$!
+
+# Wait for server to be ready
+echo "Waiting for server to start..."
+for i in {1..30}; do
+    if curl -s http://localhost:8088/std > /dev/null; then
+        echo "Server is ready!"
+        break
+    fi
+    sleep 1
+    if [ $i -eq 30 ]; then
+        echo "Server failed to start within 30 seconds"
+        exit 1
+    fi
+done
+
+# Run the tests
+cd ../../integration_tests
+hurl --test basic.hurl 


### PR DESCRIPTION
# Basic Integration Tests with Hurl

This PR adds basic integration tests using Hurl to test the Fuego framework's endpoints externally.

## Changes
- Added integration tests using Hurl
- Created test runners for both Windows (PowerShell) and Unix (Bash)
- Added documentation for running tests

## Test Coverage
- Successful POST request with JSON
- Validation error handling
- Header validation
- Standard GET endpoint

## How to Test
1. Install Hurl (`winget install Orange-OpenSource.Hurl` on Windows)
2. Run tests:
   - Windows: `.\integration_tests\run_tests.ps1`
   - Unix: `./integration_tests/run_tests.sh`

Closes #360 (Task 1)