### PR TITLE
chore: fix docs discord link with same link from readme

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -118,7 +118,7 @@ const config: Config = {
           items: [
             {
               label: "Discord",
-              href: "https://discord.gg/tdGPnnxf",
+              href: "https://discord.com/invite/s233GcZqFT",
             },
             {
               label: "Youtube",


### PR DESCRIPTION
Elected to keep the invite link to still be Ewen's name and not my own.

closes #365 