### PR TITLE
fix: path parsing issue

### DIFF
--- a/net_http_mux.go
+++ b/net_http_mux.go
@@ -10,6 +10,10 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
+type RouteConfig struct {
+	StripTrailingSlash bool
+}
+
 // Group allows grouping routes under a common path.
 // Middlewares are scoped to the group.
 // For example:
@@ -135,7 +139,12 @@ func PatchStd(s *Server, path string, controller func(http.ResponseWriter, *http
 }
 
 func registerFuegoController[T, B any](s *Server, method, path string, controller func(ContextWithBody[B]) (T, error), options ...func(*BaseRoute)) *Route[T, B] {
-	route := NewRoute[T, B](method, path, controller, s.Engine, append(s.routeOptions, options...)...)
+
+	routeConfig := RouteConfig{
+		StripTrailingSlash: s.StripTrailingSlash,
+	}
+
+	route := NewRoute[T, B](method, path, controller, s.Engine, routeConfig, append(s.routeOptions, options...)...)
 
 	acceptHeaderParameter := openapi3.NewHeaderParameter("Accept")
 	acceptHeaderParameter.Schema = openapi3.NewStringSchema().NewRef()
@@ -149,7 +158,12 @@ func registerFuegoController[T, B any](s *Server, method, path string, controlle
 }
 
 func registerStdController(s *Server, method, path string, controller func(http.ResponseWriter, *http.Request), options ...func(*BaseRoute)) *Route[any, any] {
-	route := NewRoute[any, any](method, path, controller, s.Engine, append(s.routeOptions, options...)...)
+
+	routeConfig := RouteConfig{
+		StripTrailingSlash: s.StripTrailingSlash,
+	}
+
+	route := NewRoute[any, any](method, path, controller, s.Engine, routeConfig, append(s.routeOptions, options...)...)
 
 	return Registers(s.Engine, netHttpRouteRegisterer[any, any]{
 		s:          s,

--- a/route.go
+++ b/route.go
@@ -7,7 +7,10 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-func NewRoute[T, B any](method, path string, handler any, e *Engine, options ...func(*BaseRoute)) Route[T, B] {
+func NewRoute[T, B any](method, path string, handler any, e *Engine, config RouteConfig, options ...func(*BaseRoute)) Route[T, B] {
+	if config.StripTrailingSlash && len(path) > 1 {
+		path = strings.TrimRight(path, "/")
+	}
 	return Route[T, B]{
 		BaseRoute: NewBaseRoute(method, path, handler, e, options...),
 	}

--- a/serve.go
+++ b/serve.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"reflect"
+	"strings"
 	"time"
 )
 
@@ -82,6 +83,11 @@ func (s *Server) url() string {
 // Uses Route for route configuration. Optional.
 func HTTPHandler[ReturnType, Body any](s *Server, controller func(c ContextWithBody[Body]) (ReturnType, error), route BaseRoute) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+
+		if s.StripTrailingSlash && len(r.URL.Path) > 1 {
+			r.URL.Path = strings.TrimRight(r.URL.Path, "/")
+		}
+
 		var templates *template.Template
 		if s.template != nil {
 			templates = template.Must(s.template.Clone())

--- a/server.go
+++ b/server.go
@@ -82,6 +82,9 @@ type Server struct {
 	disableStartupMessages bool
 	disableAutoGroupTags   bool
 	isTLS                  bool
+
+	// StripTrailingSlash determines if trailing slashes should be removed from routes and requests
+	StripTrailingSlash bool
 }
 
 // NewServer creates a new server with the given options.
@@ -481,5 +484,19 @@ func WithLoggingMiddleware(loggingConfig LoggingConfig) func(*Server) {
 		if loggingConfig.RequestIDFunc != nil {
 			s.loggingConfig.RequestIDFunc = loggingConfig.RequestIDFunc
 		}
+	}
+}
+
+// WithStripTrailingSlash enables stripping of trailing slashes from routes and requests
+// Default is false.
+//
+// Example:
+//
+//	app := fuego.NewServer(
+//		fuego.WithStripTrailingSlash(),
+//	)
+func WithStripTrailingSlash() func(*Server) {
+	return func(s *Server) {
+		s.StripTrailingSlash = true
 	}
 }


### PR DESCRIPTION
close #366 

@EwenQuim 

I introduced a new server property `StripTrailingSlash` that can be activated by using `withStripTrailingSlash` 

this helps remove trailing slash from defined routes and request