### PR TITLE
feat: Silence unexported fields warning

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -392,6 +392,9 @@ func parseStructTags(t reflect.Type, schemaRef *openapi3.SchemaRef) {
 
 	for i := range t.NumField() {
 		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
 		if field.Anonymous {
 			fieldType := field.Type
 			parseStructTags(fieldType, schemaRef)

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -626,3 +626,18 @@ func TestDeclareCustom200Response(t *testing.T) {
 	require.NotNil(t, openAPIResponse.Value.Content.Get("image/png"))
 	require.Equal(t, "Generated image", *openAPIResponse.Value.Description)
 }
+
+func TestPrivateFieldInStruct(t *testing.T) {
+	type User struct {
+		ID       int    `json:"id"`
+		Name     string `json:"name" validate:"required,min=1,max=100" example:"Napoleon"`
+		password string // example of private field
+	}
+
+	handler := slogassert.New(t, slog.LevelWarn, nil)
+
+	s := NewServer(WithLogHandler(handler))
+	Post(s, "/user", func(c ContextWithBody[User]) (User, error) { return c.Body() })
+
+	handler.AssertEmpty() // No warning "Property not found in schema" for the 'password' field
+}


### PR DESCRIPTION
Warning seen in #393. I think private fields tags shouldn't be processed, as they won't be seen outside anyway.

No link between the crashes in issue #393 and this warning.