### PR TITLE
Explicited time.Time behaviour for OpenAPI declaration

### DIFF
--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -14,6 +14,10 @@
 								"example": 2,
 								"type": "integer"
 							},
+							"born_date": {
+								"format": "date-time",
+								"type": "string"
+							},
 							"id": {
 								"example": "pet-123456",
 								"type": "string"
@@ -61,6 +65,10 @@
 								"description": "Age of the pet, in years",
 								"example": 2,
 								"type": "integer"
+							},
+							"born_date": {
+								"format": "date-time",
+								"type": "string"
 							},
 							"id": {
 								"example": "pet-123456",
@@ -160,6 +168,10 @@
 						"description": "Age of the pet, in years",
 						"example": 2,
 						"type": "integer"
+					},
+					"born_date": {
+						"format": "date-time",
+						"type": "string"
 					},
 					"id": {
 						"example": "pet-123456",

--- a/examples/petstore/models/Pet.go
+++ b/examples/petstore/models/Pet.go
@@ -3,6 +3,7 @@ package models
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/go-fuego/fuego"
 )
@@ -20,6 +21,7 @@ type Pets struct {
 	Age        int        `json:"age" example:"2" description:"Age of the pet, in years"`
 	IsAdopted  bool       `json:"is_adopted" description:"Is the pet adopted"`
 	References References `json:"references"`
+	BornDate   time.Time  `json:"born_date"`
 }
 
 type PetsCreate struct {

--- a/examples/petstore/models/Pet.go
+++ b/examples/petstore/models/Pet.go
@@ -21,7 +21,7 @@ type Pets struct {
 	Age        int        `json:"age" example:"2" description:"Age of the pet, in years"`
 	IsAdopted  bool       `json:"is_adopted" description:"Is the pet adopted"`
 	References References `json:"references"`
-	BornDate   time.Time  `json:"born_date"`
+	BirthDate   time.Time  `json:"birth_date"`
 }
 
 type PetsCreate struct {


### PR DESCRIPTION
Following #394, I wanted to make sure the exception for the `time.Time` struct (declared like a string), actually [managed by kin](https://github.com/getkin/kin-openapi/blob/050a930912661dd1e1a955421d60d38d2f6dd5a3/openapi3gen/openapi3gen.go#L329), is fixed in Fuego.