### PR TITLE
Use fuego.CtxRenderer in return type

### DIFF
--- a/documentation/docs/tutorials/rendering/std.md
+++ b/documentation/docs/tutorials/rendering/std.md
@@ -17,7 +17,7 @@ import (
 )
 
 // highlight-next-line
-func (rs Resource) unitPreselected(c fuego.ContextNoBody) (fuego.HTML, error) {
+func (rs Resource) unitPreselected(c fuego.ContextNoBody) (fuego.CtxRenderer, error) {
 	id := c.QueryParam("IngredientID")
 
 	ingredient, err := rs.IngredientsQueries.GetIngredient(c.Context(), id)


### PR DESCRIPTION
# Summary

`fuego.HTML` doesnt work