### PR TITLE
feat: Log error even if not fuego.HTTPError

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -146,7 +146,7 @@ func (e NotAcceptableError) Unwrap() error { return HTTPError(e) }
 
 // ErrorHandler is the default error handler used by the framework.
 // If the error is an [HTTPError] that error is returned.
-// If the error adheres to the [ErrorWithStatus] and/or [ErrorWithDetail] interface
+// If the error adheres to the [ErrorWithStatus] interface
 // the error is transformed to a [HTTPError] using [HandleHTTPError].
 // If the error is not an [HTTPError] nor does it adhere to an
 // interface the error is returned as is.
@@ -157,6 +157,8 @@ func ErrorHandler(err error) error {
 		errors.As(err, &errorStatus):
 		return HandleHTTPError(err)
 	}
+
+	slog.Error("Error in controller", "error", err.Error())
 
 	return err
 }

--- a/errors.go
+++ b/errors.go
@@ -171,6 +171,14 @@ func ErrorHandler(err error) error {
 //	engine := fuego.NewEngine(
 //		WithErrorHandler(HandleHTTPError),
 //	)
+//
+// or
+//
+//	server := fuego.NewServer(
+//		fuego.WithEngineOptions(
+//			fuego.WithErrorHandler(HandleHTTPError),
+//		),
+//	)
 func HandleHTTPError(err error) error {
 	errResponse := HTTPError{
 		Err: err,

--- a/errors_test.go
+++ b/errors_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/thejerf/slogassert"
 )
 
 type myError struct {
@@ -28,8 +29,14 @@ func TestErrorHandler(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		err := errors.New("test error")
 
+		handler := slogassert.NewDefault(t)
+
 		errResponse := ErrorHandler(err)
 		require.ErrorContains(t, errResponse, "test error")
+
+		handler.AssertMessage("Error in controller")
+
+		handler.AssertEmpty()
 	})
 
 	t.Run("not found error", func(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -753,7 +753,7 @@ func TestDefaultLoggingMiddleware(t *testing.T) {
 				require.Equal(t, "custom-func-id", rec.Header().Get("X-Request-ID"))
 			}
 
-			if tc.wantStatus == http.StatusInternalServerError {
+			if tc.wantStatus >= 400 {
 				handler.AssertMessage("Error in controller")
 			}
 

--- a/server_test.go
+++ b/server_test.go
@@ -753,6 +753,10 @@ func TestDefaultLoggingMiddleware(t *testing.T) {
 				require.Equal(t, "custom-func-id", rec.Header().Get("X-Request-ID"))
 			}
 
+			if tc.wantStatus == http.StatusInternalServerError {
+				handler.AssertMessage("Error in controller")
+			}
+
 			// all logs should be handled here
 			handler.AssertEmpty()
 		})


### PR DESCRIPTION
If returning an error that was not HTTPError error in Fuego, it wasn't logged. Now it is.