### PR TITLE
option to disable default open api server

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -52,7 +52,8 @@ type OpenAPIConfig struct {
 	DisableMessages bool
 	// If true, the engine will not save the OpenAPI JSON spec locally
 	DisableLocalSave bool
-	// If true, no default server will be added
+	// If true, no default server will be added.
+	// Note: this option only applies to the fuego [Server]. Adaptors are not affected by this option.
 	DisableDefaultServer bool
 	// Pretty prints the OpenAPI spec with proper JSON indentation
 	PrettyFormatJSON bool

--- a/engine.go
+++ b/engine.go
@@ -52,6 +52,8 @@ type OpenAPIConfig struct {
 	DisableMessages bool
 	// If true, the engine will not save the OpenAPI JSON spec locally
 	DisableLocalSave bool
+	// If true, no default server will be added
+	DisableDefaultServer bool
 	// Pretty prints the OpenAPI spec with proper JSON indentation
 	PrettyFormatJSON bool
 	// URL to serve the OpenAPI JSON spec
@@ -117,6 +119,7 @@ func WithOpenAPIConfig(config OpenAPIConfig) func(*Engine) {
 
 		e.OpenAPI.Config.Disabled = config.Disabled
 		e.OpenAPI.Config.DisableLocalSave = config.DisableLocalSave
+		e.OpenAPI.Config.DisableDefaultServer = config.DisableDefaultServer
 		e.OpenAPI.Config.PrettyFormatJSON = config.PrettyFormatJSON
 		e.OpenAPI.Config.DisableSwaggerUI = config.DisableSwaggerUI
 

--- a/serve.go
+++ b/serve.go
@@ -38,10 +38,12 @@ func (s *Server) setup() error {
 	if err := s.setupDefaultListener(); err != nil {
 		return err
 	}
-	s.OpenAPI.Description().Servers = append(s.OpenAPI.Description().Servers, &openapi3.Server{
-		URL:         s.url(),
-		Description: "local server",
-	})
+	if !s.OpenAPI.Config.DisableDefaultServer {
+		s.OpenAPI.Description().Servers = append(s.OpenAPI.Description().Servers, &openapi3.Server{
+			URL:         s.url(),
+			Description: "local server",
+		})
+	}
 	go s.OutputOpenAPISpec()
 	s.Engine.RegisterOpenAPIRoutes(s)
 	s.printStartupMessage()

--- a/server_test.go
+++ b/server_test.go
@@ -90,12 +90,13 @@ func TestWithOpenAPIConfig(t *testing.T) {
 			WithEngineOptions(
 				WithOpenAPIConfig(
 					OpenAPIConfig{
-						JSONFilePath:     "openapi.json",
-						DisableLocalSave: true,
-						PrettyFormatJSON: true,
-						Disabled:         true,
-						SwaggerURL:       "/api",
-						SpecURL:          "/api/openapi.json",
+						JSONFilePath:         "openapi.json",
+						DisableLocalSave:     true,
+						DisableDefaultServer: true,
+						PrettyFormatJSON:     true,
+						Disabled:             true,
+						SwaggerURL:           "/api",
+						SpecURL:              "/api/openapi.json",
 					}),
 			),
 		)
@@ -105,6 +106,7 @@ func TestWithOpenAPIConfig(t *testing.T) {
 		require.Equal(t, "openapi.json", s.OpenAPI.Config.JSONFilePath)
 		require.True(t, s.Engine.OpenAPI.Config.Disabled)
 		require.True(t, s.OpenAPI.Config.DisableLocalSave)
+		require.True(t, s.OpenAPI.Config.DisableDefaultServer)
 		require.True(t, s.OpenAPI.Config.PrettyFormatJSON)
 	})
 


### PR DESCRIPTION
Hi!

I added the option to not automatically add a default open API server. If no servers are added Swagger UI will use the same host you are using to browse it. This means you can try the API on all the same hostnames you can see the documentation. I prefer it that way but can see not everyone does, therefore it's an opt-in setting.