### PR TITLE
chore: improve test readability & add testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,30 @@
 run:
   go: "1.23"
   timeout: 1m
-  tests: false
+  tests: true
 
 issues:
   include:
     - "EXC0014" # Enable revive export rule with "should start with"
+  exclude-rules:
+    # Exclude other linters by default on tests files
+    # we only run testifylint https://github.com/Antonboom/testifylint on test files
+    - path: _test\.go$
+      linters:
+        - errcheck
+        - gci
+        - gofumpt
+        - gosec
+        - gosimple
+        - govet
+        - ineffassign
+        - misspell
+        - staticcheck
+        - unused
+        - usestdlibvars
+        - whitespace
+        - revive
+        - gocritic
 
 linters:
   disable-all: false
@@ -24,6 +43,7 @@ linters:
     - whitespace
     - revive
     - gocritic
+    - testifylint
 
 linters-settings:
   revive:
@@ -84,3 +104,6 @@ linters-settings:
       - default
       # linters that related to fuego, so they should be separated
       - localmodule
+
+  testifylint:
+    enable-all: true

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -127,10 +127,10 @@ func TestContext_QueryParam(t *testing.T) {
 		require.Equal(t, 456, paramInt)
 
 		paramInt = c.QueryParamInt("notfound")
-		require.Equal(t, 0, paramInt)
+		require.Zero(t, paramInt)
 
 		paramInt = c.QueryParamInt("other")
-		require.Equal(t, 0, paramInt)
+		require.Zero(t, paramInt)
 
 		paramInt, err := c.QueryParamIntErr("id")
 		require.NoError(t, err)
@@ -139,12 +139,12 @@ func TestContext_QueryParam(t *testing.T) {
 		paramInt, err = c.QueryParamIntErr("notfound")
 		require.Error(t, err)
 		require.Equal(t, "param notfound not found", err.Error())
-		require.Equal(t, 0, paramInt)
+		require.Zero(t, paramInt)
 
 		paramInt, err = c.QueryParamIntErr("other")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "param other=hello is not of type int")
-		require.Equal(t, 0, paramInt)
+		require.Zero(t, paramInt)
 	})
 
 	t.Run("bool", func(t *testing.T) {
@@ -153,22 +153,22 @@ func TestContext_QueryParam(t *testing.T) {
 		require.Equal(t, "true", param)
 
 		paramBool := c.QueryParamBool("boo")
-		require.Equal(t, true, paramBool)
+		require.True(t, paramBool)
 
 		paramBool = c.QueryParamBool("notfound")
-		require.Equal(t, false, paramBool)
+		require.False(t, paramBool)
 
 		paramBool, err := c.QueryParamBoolErr("boo")
 		require.NoError(t, err)
-		require.Equal(t, true, paramBool)
+		require.True(t, paramBool)
 
 		paramBool, err = c.QueryParamBoolErr("notfound")
 		require.Error(t, err)
-		require.Equal(t, false, paramBool)
+		require.False(t, paramBool)
 
 		paramBool, err = c.QueryParamBoolErr("other")
 		require.Error(t, err)
-		require.Equal(t, false, paramBool)
+		require.False(t, paramBool)
 	})
 
 	t.Run("slice", func(t *testing.T) {
@@ -189,8 +189,8 @@ func TestContext_QueryParams(t *testing.T) {
 
 	params := c.QueryParams()
 	require.NotEmpty(t, params)
-	require.Equal(t, params["id"], []string{"456"})
-	require.Equal(t, params["other"], []string{"hello"})
+	require.Equal(t, []string{"456"}, params["id"])
+	require.Equal(t, []string{"hello"}, params["other"])
 	require.Empty(t, params["notfound"])
 }
 
@@ -419,7 +419,7 @@ age: 30
 		body, err := c.Body()
 		require.Error(t, err)
 		require.Equal(t, "", body.Name)
-		require.Equal(t, 0, body.Age)
+		require.Zero(t, body.Age)
 	})
 
 	t.Run("can read string body", func(t *testing.T) {
@@ -557,8 +557,8 @@ func TestMainLang(t *testing.T) {
 	r.Header.Set("Accept-Language", "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5")
 
 	c := NewNetHTTPContext[any](BaseRoute{}, httptest.NewRecorder(), r, readOptions{})
-	require.Equal(t, c.MainLang(), "fr")
-	require.Equal(t, c.MainLocale(), "fr-CH")
+	require.Equal(t, "fr", c.MainLang())
+	require.Equal(t, "fr-CH", c.MainLocale())
 }
 
 func TestContextNoBody_Body(t *testing.T) {

--- a/deserialization_test.go
+++ b/deserialization_test.go
@@ -279,11 +279,11 @@ func TestConvertSQLNullString(t *testing.T) {
 func TestConvertSQLNullBool(t *testing.T) {
 	t.Run("convert sql.NullBool", func(t *testing.T) {
 		v := convertSQLNullBool("false")
-		require.Equal(t, false, v.Interface().(sql.NullBool).Bool)
+		require.False(t, v.Interface().(sql.NullBool).Bool)
 	})
 
 	t.Run("cannot convert sql.NullBool", func(t *testing.T) {
 		v := convertSQLNullBool("hello")
-		require.Equal(t, v, reflect.Value{})
+		require.Equal(t, reflect.Value{}, v)
 	})
 }

--- a/engine_test.go
+++ b/engine_test.go
@@ -67,7 +67,7 @@ func TestWithErrorHandler(t *testing.T) {
 			Err: errors.New("Not Found"),
 		}
 		errResponse := e.ErrorHandler(err)
-		require.Nil(t, errResponse, "error handler can return nil, which might lead to unexpected behavior")
+		require.NoError(t, errResponse, "error handler can return nil, which might lead to unexpected behavior")
 	})
 }
 

--- a/examples/openapi-generate/server/server.go
+++ b/examples/openapi-generate/server/server.go
@@ -12,7 +12,6 @@ func helloWorld(c fuego.ContextNoBody) (string, error) {
 // GetServer is a representation of "central" server configuration
 // that can be used in multiple places, e.g. in the main function and in the OpenAPI spec generation script.
 func GetServer() *fuego.Server {
-
 	s := fuego.NewServer()
 	// Disable local save of the OpenAPI spec after runtime
 	s.Engine.OpenAPI.Config.DisableLocalSave = true

--- a/html_test.go
+++ b/html_test.go
@@ -29,7 +29,7 @@ func TestRender(t *testing.T) {
 		s.Mux.ServeHTTP(w, r)
 
 		require.Equal(t, http.StatusOK, w.Code)
-		require.Equal(t, w.Body.String(), "<main>\n  <h1>Test</h1>\n  <p>Your name is: test</p>\n</main>\n")
+		require.Equal(t, "<main>\n  <h1>Test</h1>\n  <p>Your name is: test</p>\n</main>\n", w.Body.String())
 	})
 
 	t.Run("Render twice", func(t *testing.T) {
@@ -39,7 +39,7 @@ func TestRender(t *testing.T) {
 		s.Mux.ServeHTTP(w, r)
 
 		require.Equal(t, http.StatusOK, w.Code)
-		require.Equal(t, w.Body.String(), "<main>\n  <h1>Test</h1>\n  <p>Your name is: test</p>\n</main>\n")
+		require.Equal(t, "<main>\n  <h1>Test</h1>\n  <p>Your name is: test</p>\n</main>\n", w.Body.String())
 	})
 
 	t.Run("cannot parse unexisting file", func(t *testing.T) {

--- a/mock_context_test.go
+++ b/mock_context_test.go
@@ -154,8 +154,8 @@ func TestSearchUsersController(t *testing.T) {
 			}
 
 			// Check success cases
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, response)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, response)
 		})
 	}
 }

--- a/net_http_mux_test.go
+++ b/net_http_mux_test.go
@@ -117,8 +117,8 @@ func TestUseStd(t *testing.T) {
 
 	s.Mux.ServeHTTP(w, r)
 
-	require.Equal(t, w.Code, http.StatusOK)
-	require.Equal(t, w.Body.String(), "test successful")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "test successful", w.Body.String())
 }
 
 func TestAll(t *testing.T) {
@@ -133,7 +133,7 @@ func TestAll(t *testing.T) {
 
 		s.Mux.ServeHTTP(w, r)
 
-		require.Equal(t, w.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, w.Code)
 		require.Equal(t, "test", w.Body.String())
 	})
 
@@ -143,7 +143,7 @@ func TestAll(t *testing.T) {
 
 		s.Mux.ServeHTTP(w, r)
 
-		require.Equal(t, w.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, w.Code)
 		require.Equal(t, "test", w.Body.String())
 	})
 }
@@ -159,7 +159,7 @@ func TestGet(t *testing.T) {
 
 	s.Mux.ServeHTTP(w, r)
 
-	require.Equal(t, w.Code, http.StatusOK)
+	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, "test", w.Body.String())
 }
 
@@ -174,7 +174,7 @@ func TestPost(t *testing.T) {
 
 	s.Mux.ServeHTTP(w, r)
 
-	require.Equal(t, w.Code, http.StatusOK)
+	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, "test", w.Body.String())
 }
 
@@ -189,7 +189,7 @@ func TestPut(t *testing.T) {
 
 	s.Mux.ServeHTTP(w, r)
 
-	require.Equal(t, w.Code, http.StatusOK)
+	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, "test", w.Body.String())
 }
 
@@ -204,7 +204,7 @@ func TestPatch(t *testing.T) {
 
 	s.Mux.ServeHTTP(w, r)
 
-	require.Equal(t, w.Code, http.StatusOK)
+	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, "test", w.Body.String())
 }
 
@@ -219,8 +219,8 @@ func TestDelete(t *testing.T) {
 
 	s.Mux.ServeHTTP(w, r)
 
-	require.Equal(t, w.Code, http.StatusOK)
-	require.Equal(t, "test", "test", w.Body.String())
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "test", w.Body.String())
 }
 
 func TestHandle(t *testing.T) {
@@ -236,8 +236,8 @@ func TestHandle(t *testing.T) {
 
 	s.Mux.ServeHTTP(w, r)
 
-	require.Equal(t, w.Code, http.StatusOK)
-	require.Equal(t, w.Body.String(), "test successful")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "test successful", w.Body.String())
 }
 
 func TestAllStd(t *testing.T) {
@@ -254,8 +254,8 @@ func TestAllStd(t *testing.T) {
 
 		s.Mux.ServeHTTP(w, r)
 
-		require.Equal(t, w.Code, http.StatusOK)
-		require.Equal(t, w.Body.String(), "test successful")
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "test successful", w.Body.String())
 	})
 
 	t.Run("post", func(t *testing.T) {
@@ -265,8 +265,8 @@ func TestAllStd(t *testing.T) {
 
 		s.Mux.ServeHTTP(w, r)
 
-		require.Equal(t, w.Code, http.StatusOK)
-		require.Equal(t, w.Body.String(), "test successful")
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "test successful", w.Body.String())
 	})
 }
 
@@ -283,8 +283,8 @@ func TestGetStd(t *testing.T) {
 
 	s.Mux.ServeHTTP(w, r)
 
-	require.Equal(t, w.Code, http.StatusOK)
-	require.Equal(t, w.Body.String(), "test successful")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "test successful", w.Body.String())
 }
 
 func TestPostStd(t *testing.T) {
@@ -300,8 +300,8 @@ func TestPostStd(t *testing.T) {
 
 	s.Mux.ServeHTTP(w, r)
 
-	require.Equal(t, w.Code, http.StatusOK)
-	require.Equal(t, w.Body.String(), "test successful")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "test successful", w.Body.String())
 }
 
 func TestPutStd(t *testing.T) {
@@ -317,8 +317,8 @@ func TestPutStd(t *testing.T) {
 
 	s.Mux.ServeHTTP(w, r)
 
-	require.Equal(t, w.Code, http.StatusOK)
-	require.Equal(t, w.Body.String(), "test successful")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "test successful", w.Body.String())
 }
 
 func TestPatchStd(t *testing.T) {
@@ -334,8 +334,8 @@ func TestPatchStd(t *testing.T) {
 
 	s.Mux.ServeHTTP(w, r)
 
-	require.Equal(t, w.Code, http.StatusOK)
-	require.Equal(t, w.Body.String(), "test successful")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "test successful", w.Body.String())
 }
 
 func TestDeleteStd(t *testing.T) {
@@ -351,8 +351,8 @@ func TestDeleteStd(t *testing.T) {
 
 	s.Mux.ServeHTTP(w, r)
 
-	require.Equal(t, w.Code, http.StatusOK)
-	require.Equal(t, w.Body.String(), "test successful")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "test successful", w.Body.String())
 }
 
 func TestRegister(t *testing.T) {
@@ -435,7 +435,7 @@ func TestGroupInheritance(t *testing.T) {
 			return "test", nil
 		})
 
-		require.Equal(t, 3, len(route.Operation.Parameters))
+		require.Len(t, route.Operation.Parameters, 3)
 		require.NotNil(t, route.Operation.Parameters.GetByInAndName("header", "Header-1"))
 		require.NotNil(t, route.Operation.Parameters.GetByInAndName("header", "Header-2"))
 		require.NotNil(t, route.Operation.Parameters.GetByInAndName("header", "Accept"))
@@ -487,8 +487,8 @@ func TestHideOpenapiRoutes(t *testing.T) {
 		s.Hide()
 		Get(s, "/test", func(ctx ContextNoBody) (string, error) { return "", nil })
 
-		require.True(t, s.OpenAPI.Description().Paths.Find("/not-hidden") != nil)
-		require.True(t, s.OpenAPI.Description().Paths.Find("/test") == nil)
+		require.NotNil(t, s.OpenAPI.Description().Paths.Find("/not-hidden"))
+		require.Nil(t, s.OpenAPI.Description().Paths.Find("/test"))
 	})
 
 	t.Run("hide group", func(t *testing.T) {
@@ -498,8 +498,8 @@ func TestHideOpenapiRoutes(t *testing.T) {
 		g := Group(s, "/group").Hide()
 		Get(g, "/test", func(ctx ContextNoBody) (string, error) { return "", nil })
 
-		require.True(t, s.OpenAPI.Description().Paths.Find("/not-hidden") != nil)
-		require.True(t, s.OpenAPI.Description().Paths.Find("/group/test") == nil)
+		require.NotNil(t, s.OpenAPI.Description().Paths.Find("/not-hidden"))
+		require.Nil(t, s.OpenAPI.Description().Paths.Find("/group/test"))
 	})
 
 	t.Run("hide group but not other group", func(t *testing.T) {
@@ -510,8 +510,8 @@ func TestHideOpenapiRoutes(t *testing.T) {
 		g2 := Group(s, "/group2")
 		Get(g2, "/test", func(ctx ContextNoBody) (string, error) { return "test", nil })
 
-		require.True(t, s.OpenAPI.Description().Paths.Find("/group/test") == nil)
-		require.True(t, s.OpenAPI.Description().Paths.Find("/group2/test") != nil)
+		require.Nil(t, s.OpenAPI.Description().Paths.Find("/group/test"))
+		require.NotNil(t, s.OpenAPI.Description().Paths.Find("/group2/test"))
 	})
 
 	t.Run("hide group but show sub group", func(t *testing.T) {
@@ -522,8 +522,8 @@ func TestHideOpenapiRoutes(t *testing.T) {
 		g2 := Group(g, "/sub").Show()
 		Get(g2, "/test", func(ctx ContextNoBody) (string, error) { return "test", nil })
 
-		require.True(t, s.OpenAPI.Description().Paths.Find("/group/test") == nil)
-		require.True(t, s.OpenAPI.Description().Paths.Find("/group/sub/test") != nil)
+		require.Nil(t, s.OpenAPI.Description().Paths.Find("/group/test"))
+		require.NotNil(t, s.OpenAPI.Description().Paths.Find("/group/sub/test"))
 	})
 }
 

--- a/openapi_operations_test.go
+++ b/openapi_operations_test.go
@@ -22,7 +22,7 @@ func TestTags(t *testing.T) {
 	require.Equal(t, []string{"my-tag"}, route.Operation.Tags)
 	require.Equal(t, "#### Controller: \n\n`github.com/go-fuego/fuego.testController`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\nmy description", route.Operation.Description)
 	require.Equal(t, "my summary", route.Operation.Summary)
-	require.Equal(t, true, route.Operation.Deprecated)
+	require.True(t, route.Operation.Deprecated)
 }
 
 func TestAddTags(t *testing.T) {
@@ -33,7 +33,7 @@ func TestAddTags(t *testing.T) {
 			OptionTags("my-other-tag"),
 		)
 
-		require.Equal(t, route.Operation.Tags, []string{"my-tag", "my-other-tag"})
+		require.Equal(t, []string{"my-tag", "my-other-tag"}, route.Operation.Tags)
 	})
 
 	t.Run("with auto group tags", func(t *testing.T) {
@@ -220,7 +220,7 @@ func TestCookieParams(t *testing.T) {
 		cookieParam := route.Operation.Parameters.GetByInAndName("cookie", "my-cookie")
 		t.Logf("%#v", cookieParam.Examples["example"].Value)
 		require.Equal(t, "my description", cookieParam.Description)
-		require.Equal(t, true, cookieParam.Required)
+		require.True(t, cookieParam.Required)
 		require.Equal(t, "my-example", cookieParam.Examples["example"].Value.Value)
 	})
 }

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -238,8 +238,8 @@ func Test_tagFromType(t *testing.T) {
 		require.NotNil(t, c.Value)
 		assert.Equal(t, "my description", c.Value.Description)
 		assert.Equal(t, 8, c.Value.Example)
-		assert.Equal(t, float64(3), *c.Value.Min)
-		assert.Equal(t, float64(10), *c.Value.Max)
+		assert.InDelta(t, float64(3), *c.Value.Min, 0)
+		assert.InDelta(t, float64(10), *c.Value.Max, 0)
 	})
 
 	t.Run("struct with nested tags", func(t *testing.T) {
@@ -253,8 +253,8 @@ func Test_tagFromType(t *testing.T) {
 		require.NotNil(t, c.Value)
 		assert.Equal(t, "my description", c.Value.Description)
 		assert.Equal(t, 8, c.Value.Example)
-		assert.Equal(t, float64(3), *c.Value.Min)
-		assert.Equal(t, float64(10), *c.Value.Max)
+		assert.InDelta(t, float64(3), *c.Value.Min, 0)
+		assert.InDelta(t, float64(10), *c.Value.Max, 0)
 	})
 
 	t.Run("ensure warnings", func(t *testing.T) {
@@ -290,15 +290,15 @@ func TestServer_generateOpenAPI(t *testing.T) {
 	require.NotNil(t, document.Paths.Find("/"))
 	require.Nil(t, document.Paths.Find("/unknown"))
 	require.NotNil(t, document.Paths.Find("/post"))
-	require.Equal(t, document.Paths.Find("/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type, &openapi3.Types{"array"})
-	require.Equal(t, document.Paths.Find("/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Items.Ref, "#/components/schemas/MyStruct")
-	require.Equal(t, document.Paths.Find("/multidimensional/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type, &openapi3.Types{"array"})
-	require.Equal(t, document.Paths.Find("/multidimensional/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Items.Value.Type, &openapi3.Types{"array"})
-	require.Equal(t, document.Paths.Find("/multidimensional/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Items.Value.Items.Ref, "#/components/schemas/MyStruct")
+	require.Equal(t, &openapi3.Types{"array"}, document.Paths.Find("/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type)
+	require.Equal(t, "#/components/schemas/MyStruct", document.Paths.Find("/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Items.Ref)
+	require.Equal(t, &openapi3.Types{"array"}, document.Paths.Find("/multidimensional/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type)
+	require.Equal(t, &openapi3.Types{"array"}, document.Paths.Find("/multidimensional/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Items.Value.Type)
+	require.Equal(t, "#/components/schemas/MyStruct", document.Paths.Find("/multidimensional/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Items.Value.Items.Ref)
 	require.NotNil(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200"))
 	require.NotNil(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200").Value.Content["application/json"])
 	require.Nil(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value.Properties["unknown"])
-	require.Equal(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value.Properties["quantity"].Value.Type, &openapi3.Types{"integer"})
+	require.Equal(t, &openapi3.Types{"integer"}, document.Paths.Find("/post/{id}").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value.Properties["quantity"].Value.Type)
 
 	t.Run("openapi doc is available through a route", func(t *testing.T) {
 		w := httptest.NewRecorder()
@@ -460,25 +460,25 @@ func BenchmarkServer_generateOpenAPI(b *testing.B) {
 }
 
 func TestValidateJsonSpecURL(t *testing.T) {
-	require.Equal(t, true, validateSpecURL("/path/to/jsonSpec.json"))
-	require.Equal(t, true, validateSpecURL("/spec.json"))
-	require.Equal(t, true, validateSpecURL("/path_/jsonSpec.json"))
-	require.Equal(t, false, validateSpecURL("path/to/jsonSpec.json"))
-	require.Equal(t, false, validateSpecURL("/path/to/jsonSpec"))
-	require.Equal(t, false, validateSpecURL("/path/to/jsonSpec.jsn"))
+	require.True(t, validateSpecURL("/path/to/jsonSpec.json"))
+	require.True(t, validateSpecURL("/spec.json"))
+	require.True(t, validateSpecURL("/path_/jsonSpec.json"))
+	require.False(t, validateSpecURL("path/to/jsonSpec.json"))
+	require.False(t, validateSpecURL("/path/to/jsonSpec"))
+	require.False(t, validateSpecURL("/path/to/jsonSpec.jsn"))
 }
 
 func TestValidateSwaggerUrl(t *testing.T) {
-	require.Equal(t, true, validateSwaggerURL("/path/to/jsonSpec"))
-	require.Equal(t, true, validateSwaggerURL("/swagger"))
-	require.Equal(t, true, validateSwaggerURL("/Super-useful_swagger-2000"))
-	require.Equal(t, true, validateSwaggerURL("/Super-useful_swagger-"))
-	require.Equal(t, true, validateSwaggerURL("/Super-useful_swagger__"))
-	require.Equal(t, true, validateSwaggerURL("/Super-useful_swaggeR"))
-	require.Equal(t, false, validateSwaggerURL("/spec.json"))
-	require.Equal(t, false, validateSwaggerURL("/path_/swagger.json"))
-	require.Equal(t, false, validateSwaggerURL("path/to/jsonSpec."))
-	require.Equal(t, false, validateSwaggerURL("path/to/jsonSpec%"))
+	require.True(t, validateSwaggerURL("/path/to/jsonSpec"))
+	require.True(t, validateSwaggerURL("/swagger"))
+	require.True(t, validateSwaggerURL("/Super-useful_swagger-2000"))
+	require.True(t, validateSwaggerURL("/Super-useful_swagger-"))
+	require.True(t, validateSwaggerURL("/Super-useful_swagger__"))
+	require.True(t, validateSwaggerURL("/Super-useful_swaggeR"))
+	require.False(t, validateSwaggerURL("/spec.json"))
+	require.False(t, validateSwaggerURL("/path_/swagger.json"))
+	require.False(t, validateSwaggerURL("path/to/jsonSpec."))
+	require.False(t, validateSwaggerURL("path/to/jsonSpec%"))
 }
 
 func TestLocalSave(t *testing.T) {
@@ -561,8 +561,8 @@ func TestValidationTags(t *testing.T) {
 	require.Equal(t, expected, myTypeValue.Properties["name"].Value.Min)
 	require.Equal(t, uint64(3), myTypeValue.Properties["name"].Value.MinLength)
 	require.Equal(t, uint64(10), *myTypeValue.Properties["name"].Value.MaxLength)
-	require.Equal(t, float64(18.0), *myTypeValue.Properties["age"].Value.Min)
-	require.Equal(t, float64(100), *myTypeValue.Properties["age"].Value.Max)
+	require.InDelta(t, float64(18.0), *myTypeValue.Properties["age"].Value.Min, 0)
+	require.InDelta(t, float64(100), *myTypeValue.Properties["age"].Value.Max, 0)
 }
 
 func TestEmbeddedStructHandling(t *testing.T) {

--- a/option_test.go
+++ b/option_test.go
@@ -315,7 +315,7 @@ func TestPath(t *testing.T) {
 
 		require.Equal(t, "id", s.OpenAPI.Description().Paths.Find("/test/{id}").Get.Parameters.GetByInAndName("path", "id").Name)
 		require.Equal(t, "some id", s.OpenAPI.Description().Paths.Find("/test/{id}").Get.Parameters.GetByInAndName("path", "id").Description)
-		require.Equal(t, true, s.OpenAPI.Description().Paths.Find("/test/{id}").Get.Parameters.GetByInAndName("path", "id").Required, "path parameter is forced to be required")
+		require.True(t, s.OpenAPI.Description().Paths.Find("/test/{id}").Get.Parameters.GetByInAndName("path", "id").Required, "path parameter is forced to be required")
 	})
 
 	t.Run("Declare explicitly a non-existing path parameter for the route panics", func(t *testing.T) {
@@ -340,7 +340,7 @@ func TestRequestContentType(t *testing.T) {
 
 		s.Mux.ServeHTTP(w, r)
 
-		require.Equal(t, "{\"message\":\"hello world\"}\n", w.Body.String())
+		require.JSONEq(t, "{\"message\":\"hello world\"}\n", w.Body.String())
 		require.Len(t, route.RequestContentTypes, 1)
 		require.Equal(t, "application/json", route.RequestContentTypes[0])
 	})

--- a/param_test.go
+++ b/param_test.go
@@ -41,7 +41,7 @@ func TestParams(t *testing.T) {
 		require.Equal(t, "integer", route.Params["age"].GoType)
 
 		require.Equal(t, "Is OK?", route.Params["is_ok"].Description)
-		require.Equal(t, true, route.Params["is_ok"].Default)
+		require.True(t, route.Params["is_ok"].Default.(bool))
 
 		require.Equal(t, "Accept", route.Params["Accept"].Name)
 	})

--- a/security_test.go
+++ b/security_test.go
@@ -342,7 +342,7 @@ func TestSecurity_RefreshHandler(t *testing.T) {
 		security.RefreshHandler(w, r)
 
 		cookies := w.Result().Cookies()
-		require.Len(t, cookies, 0)
+		require.Empty(t, cookies)
 	})
 
 	t.Run("with token", func(t *testing.T) {
@@ -387,7 +387,7 @@ func TestSecurity_StdLoginHandler(t *testing.T) {
 		loginHandler(w, r)
 
 		cookies := w.Result().Cookies()
-		require.Len(t, cookies, 0)
+		require.Empty(t, cookies)
 	})
 
 	t.Run("with correct ids", func(t *testing.T) {
@@ -422,7 +422,7 @@ func TestSecurity_LoginHandler(t *testing.T) {
 		truc.ServeHTTP(w, r)
 
 		cookies := w.Result().Cookies()
-		require.Len(t, cookies, 0)
+		require.Empty(t, cookies)
 	})
 
 	t.Run("with incorrect ids", func(t *testing.T) {
@@ -435,7 +435,7 @@ func TestSecurity_LoginHandler(t *testing.T) {
 		truc.ServeHTTP(w, r)
 
 		cookies := w.Result().Cookies()
-		require.Len(t, cookies, 0)
+		require.Empty(t, cookies)
 	})
 
 	t.Run("with correct ids", func(t *testing.T) {

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -35,7 +35,7 @@ func TestSend(t *testing.T) {
 		templateToExecute: templateName,
 	})
 	body := w.Body.String()
-	require.Equal(t, "{}\n", body)
+	require.JSONEq(t, "{}\n", body)
 	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
 }
 
@@ -49,7 +49,7 @@ func TestSendWhenError(t *testing.T) {
 	SendError(w, r, err)
 	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
 	body := w.Body.String()
-	require.Equal(t, "{}\n", body)
+	require.JSONEq(t, "{}\n", body)
 }
 
 func TestRecursiveJSON(t *testing.T) {
@@ -393,7 +393,7 @@ func TestSendJSON(t *testing.T) {
 		err := SendJSON(errorWriter, nil, response{Message: "Hello World", Code: http.StatusOK})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot write on an errorWriter")
-		require.Equal(t, "{\"message\":\"Hello World\",\"code\":200}\n", errorWriter.Arg)
+		require.JSONEq(t, "{\"message\":\"Hello World\",\"code\":200}\n", errorWriter.Arg)
 	})
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -348,17 +348,17 @@ func TestGroupParams(t *testing.T) {
 	route := Get(group, "/test2", controller)
 
 	require.Equal(t, "test-value", route.Operation.Parameters.GetByInAndName("header", "X-Test-Header").Description)
-	require.Equal(t, true, route.Operation.Parameters.GetByInAndName("header", "X-Test-Header").Required)
+	require.True(t, route.Operation.Parameters.GetByInAndName("header", "X-Test-Header").Required)
 	require.Equal(t, "example", route.Operation.Parameters.GetByInAndName("header", "X-Test-Header").Examples["example"].Value.Value)
 
 	document := s.OutputOpenAPISpec()
 	t.Log(document.Paths.Find("/").Get.Parameters[0].Value.Name)
 	require.Len(t, document.Paths.Find("/").Get.Parameters, 1)
-	require.Equal(t, document.Paths.Find("/").Get.Parameters[0].Value.Name, "Accept")
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "Accept")
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "X-Test-Header")
-	require.Equal(t, document.Paths.Find("/api/test2").Get.Parameters[1].Value.Name, "Accept")
-	require.Equal(t, document.Paths.Find("/api/test2").Get.Parameters[0].Value.Name, "X-Test-Header")
+	require.Equal(t, "Accept", document.Paths.Find("/").Get.Parameters[0].Value.Name)
+	require.Equal(t, "Accept", document.Paths.Find("/api/test").Get.Parameters[1].Value.Name)
+	require.Equal(t, "X-Test-Header", document.Paths.Find("/api/test").Get.Parameters[0].Value.Name)
+	require.Equal(t, "Accept", document.Paths.Find("/api/test2").Get.Parameters[1].Value.Name)
+	require.Equal(t, "X-Test-Header", document.Paths.Find("/api/test2").Get.Parameters[0].Value.Name)
 }
 
 func TestGroupHeaderParams(t *testing.T) {
@@ -372,8 +372,8 @@ func TestGroupHeaderParams(t *testing.T) {
 	require.Equal(t, "test-value", route.Operation.Parameters.GetByInAndName("header", "X-Test-Header").Description)
 
 	document := s.OutputOpenAPISpec()
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "Accept")
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "X-Test-Header")
+	require.Equal(t, "Accept", document.Paths.Find("/api/test").Get.Parameters[1].Value.Name)
+	require.Equal(t, "X-Test-Header", document.Paths.Find("/api/test").Get.Parameters[0].Value.Name)
 }
 
 func TestGroupCookieParams(t *testing.T) {
@@ -387,8 +387,8 @@ func TestGroupCookieParams(t *testing.T) {
 	require.Equal(t, "test-value", route.Operation.Parameters.GetByInAndName("cookie", "X-Test-Cookie").Description)
 
 	document := s.OutputOpenAPISpec()
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "Accept")
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "X-Test-Cookie")
+	require.Equal(t, "Accept", document.Paths.Find("/api/test").Get.Parameters[1].Value.Name)
+	require.Equal(t, "X-Test-Cookie", document.Paths.Find("/api/test").Get.Parameters[0].Value.Name)
 }
 
 func TestGroupQueryParam(t *testing.T) {
@@ -402,8 +402,8 @@ func TestGroupQueryParam(t *testing.T) {
 	require.Equal(t, "test-value", route.Operation.Parameters.GetByInAndName("query", "X-Test-Query").Description)
 
 	document := s.OutputOpenAPISpec()
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[1].Value.Name, "Accept")
-	require.Equal(t, document.Paths.Find("/api/test").Get.Parameters[0].Value.Name, "X-Test-Query")
+	require.Equal(t, "Accept", document.Paths.Find("/api/test").Get.Parameters[1].Value.Name)
+	require.Equal(t, "X-Test-Query", document.Paths.Find("/api/test").Get.Parameters[0].Value.Name)
 }
 
 func TestGroupParamsInChildGroup(t *testing.T) {

--- a/tests_test.go
+++ b/tests_test.go
@@ -41,6 +41,6 @@ func TestContentType(t *testing.T) {
 
 		require.Equal(t, "application/json", w.Header().Get("Content-Type"))
 		require.Equal(t, 500, w.Code)
-		require.Equal(t, "{}\n", w.Body.String())
+		require.JSONEq(t, "{}\n", w.Body.String())
 	})
 }


### PR DESCRIPTION
This PR addresses https://github.com/go-fuego/fuego/issues/420 & enables testifylint for golangci-lint and fixes highlighted test assertions, improving consistency, readability and better error messages should some of these assertions fail.

All tests are still passing after the changes

For context, these where the original errors highlighted running `make ci` with testifylint enabled:

[original_errors.txt](https://github.com/user-attachments/files/18967230/original_errors.txt)
