### PR TITLE
feat: Support http.ResponseWriter options in the wrapper

### DIFF
--- a/default_middlewares.go
+++ b/default_middlewares.go
@@ -1,7 +1,9 @@
 package fuego
 
 import (
+	"bufio"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 
@@ -75,6 +77,26 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 		rw.WriteHeader(http.StatusOK)
 	}
 	return rw.ResponseWriter.Write(b)
+}
+
+func (rw *responseWriter) Flush() {
+	rw.ResponseWriter.(http.Flusher).Flush()
+}
+
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := rw.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, http.ErrNotSupported
+	}
+	return hijacker.Hijack()
+}
+
+func (rw *responseWriter) Push(target string, opts *http.PushOptions) error {
+	pusher, ok := rw.ResponseWriter.(http.Pusher)
+	if !ok {
+		return http.ErrNotSupported
+	}
+	return pusher.Push(target, opts)
 }
 
 func logRequest(requestID string, r *http.Request) {


### PR DESCRIPTION
This PR allows users to use http.Flusher even with the wrapped http.ResponseWriter.

This was a regression since Fuego supported these before the http.ResponseWriter was wrapped.