### PR TITLE
feat: Unify HTTP errors and improve error messages

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -51,10 +51,10 @@ func TestWithErrorHandler(t *testing.T) {
 	t.Run("disable error handler", func(t *testing.T) {
 		e := NewEngine(DisableErrorHandler())
 		err := NotFoundError{
-			Err: errors.New("Not Found"),
+			Err: errors.New("My Not Found Error"),
 		}
 		errResponse := e.ErrorHandler(err)
-		require.Equal(t, "Not Found", errResponse.Error())
+		require.Equal(t, "404 Not Found: My Not Found Error", errResponse.Error())
 	})
 
 	t.Run("nil returning handler", func(t *testing.T) {

--- a/serialization.go
+++ b/serialization.go
@@ -299,6 +299,12 @@ func SendHTMLError(w http.ResponseWriter, _ *http.Request, err error) {
 	}
 
 	w.WriteHeader(status)
+	var httpError HTTPError
+	if errors.As(err, &httpError) {
+		httpError.Status = status
+		_ = SendHTML(w, nil, httpError.PublicError())
+		return
+	}
 	_ = SendHTML(w, nil, err.Error())
 }
 
@@ -331,6 +337,12 @@ func SendTextError(w http.ResponseWriter, _ *http.Request, err error) {
 	}
 
 	w.WriteHeader(status)
+	var httpError HTTPError
+	if errors.As(err, &httpError) {
+		httpError.Status = status
+		_ = SendText(w, nil, httpError.PublicError())
+		return
+	}
 	_ = SendText(w, nil, err.Error())
 }
 

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -301,16 +302,16 @@ func TestSendTextError(t *testing.T) {
 		w := httptest.NewRecorder()
 		SendTextError(w, nil, errors.New("Hello World"))
 
-		require.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
-		require.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
-		require.Equal(t, "Hello World", w.Body.String())
+		assert.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
+		assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
+		assert.Equal(t, "Hello World", w.Body.String())
 	})
 	t.Run("error with status", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		SendTextError(w, nil, BadRequestError{Err: errors.New("Hello World")})
-		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
-		require.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
-		require.Equal(t, "Hello World", w.Body.String())
+		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
+		assert.Equal(t, "400 Bad Request", w.Body.String())
 	})
 }
 
@@ -476,10 +477,10 @@ func TestSendHTMLError(t *testing.T) {
 	})
 	t.Run("error with status", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendHTMLError(w, nil, BadRequestError{Err: errors.New("Hello World")})
+		SendHTMLError(w, nil, BadRequestError{Title: "My Error", Detail: "Greeting the world didn't work", Err: errors.New("Hello World failed")})
 		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		require.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
-		require.Equal(t, "Hello World", w.Body.String())
+		require.Equal(t, "400 My Error (Greeting the world didn't work)", w.Body.String())
 	})
 }
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -3,6 +3,7 @@ package fuego
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,7 +28,13 @@ func TestValidate(t *testing.T) {
 
 	var errStructValidation HTTPError
 	require.ErrorAs(t, err, &errStructValidation)
-	require.Equal(t, 400, errStructValidation.StatusCode())
-	require.Equal(t, "400 Validation Error: Name should be max=10, Age should be min=18, Required is required, Email should be a valid email, ExternalID should be a valid UUID", errStructValidation.Error())
-	require.Len(t, errStructValidation.Errors, 5)
+	assert.Equal(t, 400, errStructValidation.Status)
+	assert.Equal(t, "Validation Error", errStructValidation.Title)
+	assert.Len(t, errStructValidation.Errors, 5)
+	assert.Equal(t, "400 Validation Error (Name should be max=10, Age should be min=18, Required is required, Email should be a valid email, ExternalID should be a valid UUID)", errStructValidation.PublicError())
+	assert.EqualError(t, errStructValidation, `400 Validation Error (Name should be max=10, Age should be min=18, Required is required, Email should be a valid email, ExternalID should be a valid UUID): Key: 'validatableStruct.Name' Error:Field validation for 'Name' failed on the 'max' tag
+Key: 'validatableStruct.Age' Error:Field validation for 'Age' failed on the 'min' tag
+Key: 'validatableStruct.Required' Error:Field validation for 'Required' failed on the 'required' tag
+Key: 'validatableStruct.Email' Error:Field validation for 'Email' failed on the 'email' tag
+Key: 'validatableStruct.ExternalID' Error:Field validation for 'ExternalID' failed on the 'uuid' tag`)
 }


### PR DESCRIPTION
This PR has several goals:

- avoid nil pointer dereference (`Error() string { return e.Err.Error() } ` panics when no e.Err. Happened a lot...
- have the same behaviour for `HTTPError` and other `XxxError`s
  - Errors are formatted like `404 User Not Found (User 100 not in DB): sql: no rows in result set`
  - Error will be sent to user as `404 User Not Found (User 100 not in DB)` if HTML or text
- When using `HTTPError` or variants, hide `e.Err` from being sent to the clients for security measures
  - Use `e.Title`, `e.Details` and `e.Errors` to give informations to the clients