### PR TITLE
feat: add Server option of WithStripTrailingSlash

### DIFF
--- a/default_middlewares.go
+++ b/default_middlewares.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -156,5 +157,14 @@ func (l defaultLogger) middleware(next http.Handler) http.Handler {
 			duration := time.Since(start)
 			logResponse(r, wrapped, requestID, duration)
 		}
+	})
+}
+
+func stripTrailingSlashMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(r.URL.Path) > 1 {
+			r.URL.Path = strings.TrimRight(r.URL.Path, "/")
+		}
+		next.ServeHTTP(w, r)
 	})
 }

--- a/default_middlewares.go
+++ b/default_middlewares.go
@@ -160,6 +160,8 @@ func (l defaultLogger) middleware(next http.Handler) http.Handler {
 	})
 }
 
+// stripTrailingSlashMiddleware is a middleware that removes trailing slashes from the request path.
+// Not active by default but can be added to the server using [WithStripTrailingSlash]
 func stripTrailingSlashMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if len(r.URL.Path) > 1 {

--- a/option.go
+++ b/option.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 )
@@ -458,5 +459,15 @@ func OptionSecurity(securityRequirements ...openapi3.SecurityRequirement) func(*
 
 		// Append all provided security requirements
 		*r.Operation.Security = append(*r.Operation.Security, securityRequirements...)
+	}
+}
+
+// OptionStripTrailingSlash ensure that the route declaration
+// will have its ending trailing slash stripped.
+func OptionStripTrailingSlash() func(*BaseRoute) {
+	return func(r *BaseRoute) {
+		if len(r.Path) > 1 {
+			r.Path = strings.TrimRight(r.Path, "/")
+		}
 	}
 }

--- a/option/option.go
+++ b/option/option.go
@@ -180,3 +180,7 @@ var Show = fuego.OptionShow
 
 // DefaultStatusCode sets the default status code for the route.
 var DefaultStatusCode = fuego.OptionDefaultStatusCode
+
+// StripTrailingSlash removes the trailing slash from the route.
+// By default, the trailing slash is kept, so becauseful when registering route like "/" within a group.
+var StripTrailingSlash = fuego.OptionStripTrailingSlash

--- a/option_test.go
+++ b/option_test.go
@@ -1016,3 +1016,11 @@ func TestDefaultStatusCode(t *testing.T) {
 		require.Equal(t, 500, w.Code)
 	})
 }
+
+func TestOptionStripTrailingSlash(t *testing.T) {
+	t.Run("Route trailing slash is stripped", func(t *testing.T) {
+		s := fuego.NewServer()
+		route := fuego.Get(s, "/test/", helloWorld, fuego.OptionStripTrailingSlash())
+		require.Equal(t, "/test", route.Path)
+	})
+}

--- a/server.go
+++ b/server.go
@@ -449,3 +449,13 @@ func WithLoggingMiddleware(loggingConfig LoggingConfig) func(*Server) {
 		}
 	}
 }
+
+// WithStripTrailingSlash ensure all declared routes trailing slash
+// is stripped. This option also applies a middleware
+// that strips the trailing slash from every incoming request.
+func WithStripTrailingSlash() func(*Server) {
+	return func(s *Server) {
+		s.routeOptions = append(s.routeOptions, OptionStripTrailingSlash())
+		s.globalMiddlewares = append(s.globalMiddlewares, stripTrailingSlashMiddleware)
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -843,3 +843,57 @@ func TestWithSeveralGlobalMiddelwares(t *testing.T) {
 		require.Equal(t, "two", res.Body.String())
 	})
 }
+
+func TestWithStripTrailingSlash(t *testing.T) {
+	s := NewServer(
+		WithStripTrailingSlash(),
+		WithAddr(":9998"),
+	)
+	Get(s, "/withtrailingslash/", dummyController)
+	Get(s, "/withouttrailingslash", dummyController)
+
+	err := s.setup()
+	require.NoError(t, err)
+
+	t.Run("requests with trailing slash", func(t *testing.T) {
+		t.Run("route with trailing slash", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/withtrailingslash/", nil)
+			res := httptest.NewRecorder()
+
+			s.Handler.ServeHTTP(res, req)
+
+			t.Log(res.Body.String())
+			require.Equal(t, 200, res.Code)
+		})
+		t.Run("route without trailing slash", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/withouttrailingslash/", nil)
+			res := httptest.NewRecorder()
+
+			s.Handler.ServeHTTP(res, req)
+
+			t.Log(res.Body.String())
+			require.Equal(t, 200, res.Code)
+		})
+	})
+
+	t.Run("requests without trailing slash", func(t *testing.T) {
+		t.Run("route with trailing slash", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/withtrailingslash", nil)
+			res := httptest.NewRecorder()
+
+			s.Handler.ServeHTTP(res, req)
+
+			t.Log(res.Body.String())
+			require.Equal(t, 200, res.Code)
+		})
+		t.Run("route without trailing slash", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/withouttrailingslash", nil)
+			res := httptest.NewRecorder()
+
+			s.Handler.ServeHTTP(res, req)
+
+			t.Log(res.Body.String())
+			require.Equal(t, 200, res.Code)
+		})
+	})
+}

--- a/server_test.go
+++ b/server_test.go
@@ -849,7 +849,7 @@ func TestWithStripTrailingSlash(t *testing.T) {
 		WithStripTrailingSlash(),
 		WithAddr(":9998"),
 	)
-	Get(s, "/withtrailingslash/", dummyController)
+	Get(s, "/withtrailingslash/", dummyController) // Will be registered as /withtrailingslash
 	Get(s, "/withouttrailingslash", dummyController)
 
 	err := s.setup()


### PR DESCRIPTION
closes #366

Add the ability for a user to implicitly strip all slashes from all routes as well as strip all ending slashes from all requests at the fuego Server level.

This PR only makes this configurable at the level of the Server. This does come with a utility function to be able to configure path stripping at the route level but it's not incredibly useful (our uses should just do this themselves when they declare the path). 

Let me know what you think. It may be worth make that option private as it's not really useful unless you're stripping at the global level. 