### PR TITLE
fix: skip calling Flush on responseWriter when it is not implemented

### DIFF
--- a/default_middlewares.go
+++ b/default_middlewares.go
@@ -81,7 +81,12 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 }
 
 func (rw *responseWriter) Flush() {
-	rw.ResponseWriter.(http.Flusher).Flush()
+	flusher, ok := rw.ResponseWriter.(http.Flusher)
+	if !ok {
+		slog.Warn("Flush not implemented, skipping")
+		return
+	}
+	flusher.Flush()
 }
 
 func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {

--- a/default_middlewares_test.go
+++ b/default_middlewares_test.go
@@ -1,0 +1,44 @@
+package fuego
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/thejerf/slogassert"
+)
+
+type TestResponseWriter struct{}
+
+func (w *TestResponseWriter) Header() http.Header {
+	panic("not implemented")
+}
+
+func (w *TestResponseWriter) Write(b []byte) (int, error) {
+	panic("not implemented")
+}
+
+func (w *TestResponseWriter) WriteHeader(statusCode int) {
+	panic("not implemented")
+}
+
+func TestFlush(t *testing.T) {
+	t.Run("is implemented", func(t *testing.T) {
+		handler := slogassert.New(t, slog.LevelWarn, nil)
+		slog.SetDefault(slog.New(handler))
+
+		rw := newResponseWriter(httptest.NewRecorder())
+		rw.Flush()
+		handler.AssertEmpty()
+	})
+	t.Run("is not implemented", func(t *testing.T) {
+		handler := slogassert.New(t, slog.LevelWarn, nil)
+		slog.SetDefault(slog.New(handler))
+
+		rw := newResponseWriter(&TestResponseWriter{})
+		rw.Flush()
+		handler.AssertMessage("Flush not implemented, skipping")
+		handler.AssertEmpty()
+	})
+}


### PR DESCRIPTION
Closes #439 

- Protects against a panic in the case where ResponseWriter.Flush is not implemented
- Logs a warn message if flush is not implemented