### PR TITLE
fix: default status code for echo

### DIFF
--- a/extra/fuegoecho/context.go
+++ b/extra/fuegoecho/context.go
@@ -114,9 +114,6 @@ func (c echoContext[B]) SetStatus(code int) {
 func (c echoContext[B]) Serialize(data any) error {
 	status := c.echoCtx.Response().Status
 	if status == 0 {
-		status = c.DefaultStatusCode
-	}
-	if status == 0 {
 		status = http.StatusOK
 	}
 	c.echoCtx.JSON(status, data)
@@ -136,5 +133,5 @@ func (c echoContext[B]) SetDefaultStatusCode() {
 	if c.DefaultStatusCode == 0 {
 		c.DefaultStatusCode = http.StatusOK
 	}
-	c.SetStatus(c.DefaultStatusCode)
+	c.echoCtx.Response().Status = c.DefaultStatusCode
 }

--- a/extra/fuegogin/context.go
+++ b/extra/fuegogin/context.go
@@ -114,9 +114,6 @@ func (c ginContext[B]) SetStatus(code int) {
 func (c ginContext[B]) Serialize(data any) error {
 	status := c.ginCtx.Writer.Status()
 	if status == 0 {
-		status = c.DefaultStatusCode
-	}
-	if status == 0 {
 		status = http.StatusOK
 	}
 	c.ginCtx.JSON(status, data)


### PR DESCRIPTION
Relates to #375

Echo is actually writing `text/plain` for all responses not even in cases where we set Default status code is used. This fixes it for both cases. Leaving only fuego with the default status code bug. Gin actually works to do it's set status helper

Note: should we update the `DefaultStatusCode` comment docs to state that this option does not work with fuego Server?

Another note: I can't really provide a test on this besides for some pics as we don't have a e2e test. `httptest.ResponseWriter` implementation allows for the header to be overwritten through the test. I think this raises for #360 to be opened 🫤 sorry about not being clear on my original concerns.

Here is the echo server before and after btw:

before: 
<img width="524" alt="image" src="https://github.com/user-attachments/assets/c4c6ac7c-2c18-4477-bd3d-3e01ed00f419" />

After:
<img width="526" alt="image" src="https://github.com/user-attachments/assets/4423ff2e-b5d1-4ba1-8409-c52ebd36b52a" />

I know we like tests but this is pretty significant, and getting an e2e test suite up is gonna take some thinking. We probably want to get something together to ensure the adaptors do what we expect.