### PR TITLE
feat: Allow non-.json paths for OpenAPI specs

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -119,7 +119,7 @@ func (s *Server) Show() *Server {
 }
 
 func validateSpecURL(specURL string) bool {
-	specURLRegexp := regexp.MustCompile(`^\/[\/a-zA-Z0-9\-\_]+$`)
+	specURLRegexp := regexp.MustCompile(`^\/[\/a-zA-Z0-9\-\_\.]+$`)
 	return specURLRegexp.MatchString(specURL)
 }
 

--- a/openapi.go
+++ b/openapi.go
@@ -119,7 +119,7 @@ func (s *Server) Show() *Server {
 }
 
 func validateSpecURL(specURL string) bool {
-	specURLRegexp := regexp.MustCompile(`^\/[\/a-zA-Z0-9\-\_]+(.json)$`)
+	specURLRegexp := regexp.MustCompile(`^\/[\/a-zA-Z0-9\-\_]+$`)
 	return specURLRegexp.MatchString(specURL)
 }
 

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -488,13 +488,23 @@ func BenchmarkServer_generateOpenAPI(b *testing.B) {
 	}
 }
 
-func TestValidateJsonSpecURL(t *testing.T) {
+func TestValidateSpecURL(t *testing.T) {
 	require.True(t, validateSpecURL("/path/to/jsonSpec.json"))
 	require.True(t, validateSpecURL("/spec.json"))
 	require.True(t, validateSpecURL("/path_/jsonSpec.json"))
+	require.True(t, validateSpecURL("/openapi.yaml"))
+	require.True(t, validateSpecURL("/_specs.json"))
+	require.True(t, validateSpecURL("/SPECS123"))
+	require.True(t, validateSpecURL("/openapi/specs/in/a/nested/dir"))
+	require.True(t, validateSpecURL("/_"))
+	require.True(t, validateSpecURL("/-.json"))
+	
 	require.False(t, validateSpecURL("path/to/jsonSpec.json"))
-	require.False(t, validateSpecURL("/path/to/jsonSpec"))
-	require.False(t, validateSpecURL("/path/to/jsonSpec.jsn"))
+	require.False(t, validateSpecURL("/späcs"))
+	require.False(t, validateSpecURL("/$pecs"))
+	require.False(t, validateSpecURL("/"))
+	require.False(t, validateSpecURL(""))
+	require.False(t, validateSpecURL("a"))
 }
 
 func TestValidateSwaggerUrl(t *testing.T) {

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -498,7 +498,7 @@ func TestValidateSpecURL(t *testing.T) {
 	require.True(t, validateSpecURL("/openapi/specs/in/a/nested/dir"))
 	require.True(t, validateSpecURL("/_"))
 	require.True(t, validateSpecURL("/-.json"))
-	
+
 	require.False(t, validateSpecURL("path/to/jsonSpec.json"))
 	require.False(t, validateSpecURL("/späcs"))
 	require.False(t, validateSpecURL("/$pecs"))


### PR DESCRIPTION
# Changes
Allow non-.json paths for OpenAPI specs, for example:
```go
s := fuego.NewServer(
        fuego.WithEngineOptions(
	        fuego.WithOpenAPIConfig(fuego.OpenAPIConfig{
		        SpecURL:          "/api-specs",  // no .json needed
	        }),
        ),
)
```
The mandatory ".json" extension has been removed, allowing paths like `/openapi`, `/api-specs`, or `/specs` without an error message. Now by default I still get json, but if I use the "accept: application/yaml" I can get the yaml specs. Btw, it is weird to use a non-json "accept" on a .json endpoint.

# Miscellaneous questions
## 1. Pull requests
**I do this PR on the main branch, is that meant to be?**
## 2. Tests
`make ci` gave me test failures right after the cloning the `main`:
- `FAIL    github.com/go-fuego/fuego       1.781s`
- `FAIL    github.com/go-fuego/fuego/extra/sqlite3 [build failed]`

I tired on ubuntu & macos, go v1.24.2.
So i not rlly tested the changes i made, as the CONTRIBUTING.md told me to do.
**How should i proceed in this case?**
## 3. CONTRIBUTING.md
The [CONTRIBUTING.md](https://github.com/go-fuego/fuego/blob/main/CONTRIBUTING.md) file is poorly developed and could be more precise.
**Are people allowed to create a PR's for updating the CONTRIBUTING.md?**

_thanks in advance and happy developing_ 