### PR TITLE
fix: add detail/status for queryparam errs and detail for path errs

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -229,10 +229,14 @@ type PathParamNotFoundError struct {
 }
 
 func (e PathParamNotFoundError) Error() string {
-	return fmt.Errorf("param %s not found", e.ParamName).Error()
+	return fmt.Sprintf("path param %s not found", e.ParamName)
 }
 
-func (e PathParamNotFoundError) StatusCode() int { return 404 }
+func (e PathParamNotFoundError) StatusCode() int { return http.StatusUnprocessableEntity }
+
+func (e PathParamNotFoundError) DetailMsg() string {
+	return e.Error()
+}
 
 type PathParamInvalidTypeError struct {
 	Err          error
@@ -242,10 +246,14 @@ type PathParamInvalidTypeError struct {
 }
 
 func (e PathParamInvalidTypeError) Error() string {
-	return fmt.Errorf("param %s=%s is not of type %s: %w", e.ParamName, e.ParamValue, e.ExpectedType, e.Err).Error()
+	return fmt.Sprintf("path param %s=%s is not of type %s: %s", e.ParamName, e.ParamValue, e.ExpectedType, e.Err.Error())
 }
 
-func (e PathParamInvalidTypeError) StatusCode() int { return 422 }
+func (e PathParamInvalidTypeError) StatusCode() int { return http.StatusUnprocessableEntity }
+
+func (e PathParamInvalidTypeError) DetailMsg() string {
+	return e.Error()
+}
 
 type ContextWithPathParam interface {
 	PathParam(name string) string

--- a/ctx.go
+++ b/ctx.go
@@ -246,13 +246,13 @@ type PathParamInvalidTypeError struct {
 }
 
 func (e PathParamInvalidTypeError) Error() string {
-	return fmt.Sprintf("path param %s=%s is not of type %s: %s", e.ParamName, e.ParamValue, e.ExpectedType, e.Err.Error())
+	return fmt.Sprintf("%s: %s", e.DetailMsg(), e.Err)
 }
 
 func (e PathParamInvalidTypeError) StatusCode() int { return http.StatusUnprocessableEntity }
 
 func (e PathParamInvalidTypeError) DetailMsg() string {
-	return e.Error()
+	return fmt.Sprintf("path param %s=%s is not of type %s", e.ParamName, e.ParamValue, e.ExpectedType)
 }
 
 type ContextWithPathParam interface {

--- a/internal/common_context.go
+++ b/internal/common_context.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"net/http"
 	"net/url"
 	"slices"
 	"strconv"
@@ -140,7 +141,13 @@ type QueryParamNotFoundError struct {
 }
 
 func (e QueryParamNotFoundError) Error() string {
-	return fmt.Errorf("param %s not found", e.ParamName).Error()
+	return fmt.Sprintf("param %s not found", e.ParamName)
+}
+
+func (e QueryParamNotFoundError) StatusCode() int { return http.StatusUnprocessableEntity }
+
+func (e QueryParamNotFoundError) DetailMsg() string {
+	return e.Error()
 }
 
 type QueryParamInvalidTypeError struct {
@@ -151,7 +158,13 @@ type QueryParamInvalidTypeError struct {
 }
 
 func (e QueryParamInvalidTypeError) Error() string {
-	return fmt.Errorf("param %s=%s is not of type %s: %w", e.ParamName, e.ParamValue, e.ExpectedType, e.Err).Error()
+	return fmt.Sprintf("query param %s=%s is not of type %s: %s", e.ParamName, e.ParamValue, e.ExpectedType, e.Err.Error())
+}
+
+func (e QueryParamInvalidTypeError) StatusCode() int { return http.StatusUnprocessableEntity }
+
+func (e QueryParamInvalidTypeError) DetailMsg() string {
+	return e.Error()
 }
 
 // QueryParamArr returns an slice of string from the given query parameter.

--- a/internal/common_context.go
+++ b/internal/common_context.go
@@ -158,13 +158,13 @@ type QueryParamInvalidTypeError struct {
 }
 
 func (e QueryParamInvalidTypeError) Error() string {
-	return fmt.Sprintf("query param %s=%s is not of type %s: %s", e.ParamName, e.ParamValue, e.ExpectedType, e.Err.Error())
+	return fmt.Sprintf("%s: %s", e.DetailMsg(), e.Err)
 }
 
 func (e QueryParamInvalidTypeError) StatusCode() int { return http.StatusUnprocessableEntity }
 
 func (e QueryParamInvalidTypeError) DetailMsg() string {
-	return e.Error()
+	return fmt.Sprintf("query param %s=%s is not of type %s", e.ParamName, e.ParamValue, e.ExpectedType)
 }
 
 // QueryParamArr returns an slice of string from the given query parameter.


### PR DESCRIPTION
Indirectly closes my concerns with #386 and could make #419 unneeded.

```
PathParamNotFoundError
PathParamInvalidTypeError
QueryParamNotFoundError
QueryParamInvalidTypeError
```

All to adhere to the interfaces of `ErrorWithStatus` and `ErrorWithDetail`. In our default errorhandler in the case of the implementation of `ErrorWithStatus` we cast the error to HTTPError anyway. This will also expose the error as Detail ensure we're returning. 

Let me know what you guys think. I don't see the point of copying HTTPError into common Context just to support in both places when we can just implement the interface. See this comment for some context on that: https://github.com/go-fuego/fuego/pull/419#discussion_r1975070317. I did work my way through half this solution before I realized we could just do this.

Let me know what you all think. There isn't really any tests testing the literal error type. I'd like to add it if you guys like this approach, but yeah right now the only real tests around this mainly look like this:

```golang
		paramInt, err = c.QueryParamIntErr("other")
		require.Error(t, err)
		require.Contains(t, err.Error(), "param other=hello is not of type int")
		require.Zero(t, paramInt)
``` 