### PR TITLE
fix: allow setting disable messages from openapi config

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -123,6 +123,7 @@ func WithOpenAPIConfig(config OpenAPIConfig) func(*Engine) {
 		e.OpenAPI.Config.DisableDefaultServer = config.DisableDefaultServer
 		e.OpenAPI.Config.PrettyFormatJSON = config.PrettyFormatJSON
 		e.OpenAPI.Config.DisableSwaggerUI = config.DisableSwaggerUI
+		e.OpenAPI.Config.DisableMessages = config.DisableMessages
 
 		if !validateSpecURL(e.OpenAPI.Config.SpecURL) {
 			slog.Error("Error serving OpenAPI JSON spec. Value of 's.OpenAPIServerConfig.SpecURL' option is not valid", "url", e.OpenAPI.Config.SpecURL)

--- a/server_test.go
+++ b/server_test.go
@@ -92,6 +92,7 @@ func TestWithOpenAPIConfig(t *testing.T) {
 						JSONFilePath:         "openapi.json",
 						DisableLocalSave:     true,
 						DisableDefaultServer: true,
+						DisableMessages:      true,
 						PrettyFormatJSON:     true,
 						Disabled:             true,
 						SwaggerURL:           "/api",
@@ -106,6 +107,7 @@ func TestWithOpenAPIConfig(t *testing.T) {
 		require.True(t, s.Engine.OpenAPI.Config.Disabled)
 		require.True(t, s.OpenAPI.Config.DisableLocalSave)
 		require.True(t, s.OpenAPI.Config.DisableDefaultServer)
+		require.True(t, s.OpenAPI.Config.DisableMessages)
 		require.True(t, s.OpenAPI.Config.PrettyFormatJSON)
 	})
 


### PR DESCRIPTION
Noticed that this property wasn't being passed through when I configured the fuego instance.