### PR TITLE
BREAKING: use slog.***Context where applicable 

### DIFF
--- a/deserialization.go
+++ b/deserialization.go
@@ -102,7 +102,7 @@ func read[B any](ctx context.Context, dec decoder) (B, error) {
 			Detail: "cannot decode request body: " + err.Error(),
 		}
 	}
-	slog.Debug("Decoded body", "body", body)
+	slog.DebugContext(ctx, "Decoded body", "body", body)
 
 	return TransformAndValidate(ctx, body)
 }
@@ -125,7 +125,7 @@ func readString[B ~string](ctx context.Context, input io.Reader, _ readOptions) 
 	}
 
 	body := B(readBody)
-	slog.Debug("Read body", "body", body)
+	slog.DebugContext(ctx, "Read body", "body", body)
 
 	return transform(ctx, body)
 }
@@ -183,7 +183,7 @@ func readURLEncoded[B any](r *http.Request, options readOptions) (B, error) {
 			},
 		}
 	}
-	slog.Debug("Decoded body", "body", body)
+	slog.DebugContext(r.Context(), "Decoded body", "body", body)
 
 	return TransformAndValidate(r.Context(), body)
 }
@@ -204,7 +204,7 @@ func transform[B any](ctx context.Context, body B) (B, error) {
 		}
 		body = *any(inTransformerBody).(*B)
 
-		slog.Debug("InTransformd body", "body", body)
+		slog.DebugContext(ctx, "InTransformd body", "body", body)
 	}
 
 	return body, nil

--- a/engine.go
+++ b/engine.go
@@ -38,7 +38,7 @@ func NewEngine(options ...func(*Engine)) *Engine {
 // The Engine is the main struct of the framework.
 type Engine struct {
 	OpenAPI      *OpenAPI
-	ErrorHandler func(error) error
+	ErrorHandler func(context.Context, error) error
 
 	requestContentTypes []string
 }
@@ -139,7 +139,7 @@ func WithOpenAPIConfig(config OpenAPIConfig) func(*Engine) {
 }
 
 // WithErrorHandler sets a customer error handler for the server
-func WithErrorHandler(errorHandler func(err error) error) func(*Engine) {
+func WithErrorHandler(errorHandler func(ctx context.Context, err error) error) func(*Engine) {
 	return func(e *Engine) {
 		if errorHandler == nil {
 			panic("errorHandler cannot be nil")
@@ -152,7 +152,7 @@ func WithErrorHandler(errorHandler func(err error) error) func(*Engine) {
 // DisableErrorHandler overrides ErrorHandler with a simple pass-through
 func DisableErrorHandler() func(*Engine) {
 	return func(e *Engine) {
-		e.ErrorHandler = func(err error) error { return err }
+		e.ErrorHandler = func(_ context.Context, err error) error { return err }
 	}
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,6 +1,7 @@
 package fuego
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -32,7 +33,7 @@ func TestErrorHandler(t *testing.T) {
 
 		handler := slogassert.NewDefault(t)
 
-		errResponse := ErrorHandler(err)
+		errResponse := ErrorHandler(context.Background(), err)
 		require.ErrorContains(t, errResponse, "test error")
 
 		handler.AssertMessage("Error in controller")
@@ -44,7 +45,7 @@ func TestErrorHandler(t *testing.T) {
 		err := NotFoundError{
 			Err: errors.New("Not Found :c"),
 		}
-		errResponse := ErrorHandler(err)
+		errResponse := ErrorHandler(context.Background(), err)
 		require.ErrorAs(t, errResponse, &HTTPError{})
 		require.ErrorContains(t, err, "Not Found :c")
 		require.ErrorContains(t, errResponse, "Not Found")
@@ -56,7 +57,7 @@ func TestErrorHandler(t *testing.T) {
 		err := HTTPError{
 			Err: errors.New("HTTPError"),
 		}
-		errResponse := ErrorHandler(err)
+		errResponse := ErrorHandler(context.Background(), err)
 
 		var httpError HTTPError
 		require.ErrorAs(t, errResponse, &httpError)
@@ -68,7 +69,7 @@ func TestErrorHandler(t *testing.T) {
 		err := myError{
 			status: http.StatusNotFound,
 		}
-		errResponse := ErrorHandler(err)
+		errResponse := ErrorHandler(context.Background(), err)
 		require.ErrorAs(t, errResponse, &HTTPError{})
 		require.ErrorContains(t, errResponse, "Not Found")
 		require.ErrorContains(t, errResponse, "404")
@@ -79,7 +80,7 @@ func TestErrorHandler(t *testing.T) {
 		err := myError{
 			detail: "my detail",
 		}
-		errResponse := ErrorHandler(err)
+		errResponse := ErrorHandler(context.Background(), err)
 		require.ErrorAs(t, errResponse, &HTTPError{})
 		require.Contains(t, errResponse.Error(), "Internal Server Error")
 		require.Contains(t, errResponse.Error(), "500")
@@ -91,7 +92,7 @@ func TestErrorHandler(t *testing.T) {
 		err := ConflictError{
 			Err: errors.New("Conflict"),
 		}
-		errResponse := ErrorHandler(err)
+		errResponse := ErrorHandler(context.Background(), err)
 		require.ErrorAs(t, errResponse, &HTTPError{})
 		require.ErrorContains(t, err, "Conflict")
 		require.ErrorContains(t, errResponse, "Conflict")
@@ -103,7 +104,7 @@ func TestErrorHandler(t *testing.T) {
 		err := UnauthorizedError{
 			Err: errors.New("coucou"),
 		}
-		errResponse := ErrorHandler(err)
+		errResponse := ErrorHandler(context.Background(), err)
 		require.ErrorAs(t, errResponse, &HTTPError{})
 		require.ErrorContains(t, err, "coucou")
 		require.ErrorContains(t, errResponse, "Unauthorized")
@@ -115,7 +116,7 @@ func TestErrorHandler(t *testing.T) {
 		err := ForbiddenError{
 			Err: errors.New("Forbidden"),
 		}
-		errResponse := ErrorHandler(err)
+		errResponse := ErrorHandler(context.Background(), err)
 		require.ErrorAs(t, errResponse, &HTTPError{})
 		require.ErrorContains(t, err, "Forbidden")
 		require.ErrorContains(t, errResponse, "Forbidden")
@@ -128,7 +129,7 @@ func TestHandleHTTPError(t *testing.T) {
 	t.Run("should always be HTTPError", func(t *testing.T) {
 		err := errors.New("test error")
 
-		errResponse := HandleHTTPError(err)
+		errResponse := HandleHTTPError(context.Background(), err)
 		require.ErrorAs(t, errResponse, &HTTPError{})
 		require.ErrorContains(t, errResponse, "500 Internal Server Error")
 	})
@@ -137,7 +138,7 @@ func TestHandleHTTPError(t *testing.T) {
 		err := NotFoundError{
 			Err: errors.New("Not Found :c"),
 		}
-		errResponse := HandleHTTPError(err)
+		errResponse := HandleHTTPError(context.Background(), err)
 		require.ErrorAs(t, errResponse, &HTTPError{})
 		require.ErrorContains(t, err, "Not Found :c")
 		require.ErrorContains(t, errResponse, "Not Found")

--- a/internal/common_context.go
+++ b/internal/common_context.go
@@ -102,7 +102,7 @@ func (c CommonContext[B]) HasQueryParam(name string) bool {
 func (c CommonContext[B]) QueryParam(name string) string {
 	_, ok := c.OpenAPIParams[name]
 	if !ok {
-		slog.Warn("query parameter not expected in OpenAPI spec", "param", name, "expected_one_of", slices.Collect(maps.Keys(c.OpenAPIParams)))
+		slog.WarnContext(c.CommonCtx, "query parameter not expected in OpenAPI spec", "param", name, "expected_one_of", slices.Collect(maps.Keys(c.OpenAPIParams)))
 	}
 
 	if !c.UrlValues.Has(name) {
@@ -171,7 +171,7 @@ func (e QueryParamInvalidTypeError) DetailMsg() string {
 func (c CommonContext[B]) QueryParamArr(name string) []string {
 	_, ok := c.OpenAPIParams[name]
 	if !ok {
-		slog.Warn("query parameter not expected in OpenAPI spec", "param", name)
+		slog.WarnContext(c.CommonCtx, "query parameter not expected in OpenAPI spec", "param", name)
 	}
 	return c.UrlValues[name]
 }

--- a/serialization.go
+++ b/serialization.go
@@ -89,15 +89,15 @@ func Send(w http.ResponseWriter, r *http.Request, ans any) (err error) {
 	for _, header := range parseAcceptHeader(r.Header) {
 		switch inferAcceptHeader(header, ans) {
 		case "application/xml":
-			err = SendXML(w, nil, ans)
+			err = SendXML(w, r, ans)
 		case "text/html":
 			err = SendHTML(w, r, ans)
 		case "text/plain":
-			err = SendText(w, nil, ans)
+			err = SendText(w, r, ans)
 		case "application/json":
-			err = SendJSON(w, nil, ans)
+			err = SendJSON(w, r, ans)
 		case "application/x-yaml", "text/yaml; charset=utf-8", "application/yaml": // https://www.rfc-editor.org/rfc/rfc9512.html
-			err = SendYAML(w, nil, ans)
+			err = SendYAML(w, r, ans)
 		default:
 			// if we don't support the header, try the next one
 			continue

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -62,7 +62,7 @@ func TestRecursiveJSON(t *testing.T) {
 		w := httptest.NewRecorder()
 		value := rec{}
 		value.Rec = &value
-		err := SendJSON(w, nil, value)
+		err := SendJSON(w, httptest.NewRequest("", "/", nil), value)
 
 		require.Error(t, err)
 	})
@@ -71,7 +71,7 @@ func TestRecursiveJSON(t *testing.T) {
 func TestJSON(t *testing.T) {
 	t.Run("can serialize json", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendJSON(w, nil, response{Message: "Hello World", Code: 200})
+		SendJSON(w, httptest.NewRequest("", "/", nil), response{Message: "Hello World", Code: 200})
 		body := w.Body.String()
 
 		require.Equal(t, crlf(`{"message":"Hello World","code":200}`), body)
@@ -79,7 +79,7 @@ func TestJSON(t *testing.T) {
 
 	t.Run("cannot serialize functions", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		err := SendJSON(w, nil, func() {})
+		err := SendJSON(w, httptest.NewRequest("", "/", nil), func() {})
 		require.Error(t, err)
 		require.ErrorAs(t, err, &NotAcceptableError{})
 
@@ -91,7 +91,7 @@ func TestJSON(t *testing.T) {
 func TestXML(t *testing.T) {
 	t.Run("can serialize xml", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		err := SendXML(w, nil, response{Message: "Hello World", Code: 200})
+		err := SendXML(w, httptest.NewRequest("", "/", nil), response{Message: "Hello World", Code: 200})
 		require.NoError(t, err)
 		body := w.Body.String()
 
@@ -100,7 +100,7 @@ func TestXML(t *testing.T) {
 
 	t.Run("cannot serialize functions", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		err := SendXML(w, nil, func() {})
+		err := SendXML(w, httptest.NewRequest("", "/", nil), func() {})
 		require.Error(t, err)
 		require.ErrorAs(t, err, &NotAcceptableError{})
 
@@ -111,7 +111,7 @@ func TestXML(t *testing.T) {
 	t.Run("can serialize xml error", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		err := HTTPError{Detail: "Hello World"}
-		SendXMLError(w, nil, err)
+		SendXMLError(w, httptest.NewRequest("", "/", nil), err)
 		body := w.Body.String()
 
 		require.Equal(t, `<HTTPError><detail>Hello World</detail></HTTPError>`, body)
@@ -333,14 +333,14 @@ func (errorWriter) Header() http.Header {
 func TestSendYAML(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendYAML(w, nil, response{Message: "Hello World", Code: http.StatusOK})
+		SendYAML(w, httptest.NewRequest("", "/", nil), response{Message: "Hello World", Code: http.StatusOK})
 		require.Equal(t, "application/x-yaml", w.Header().Get("Content-Type"))
 		require.Equal(t, "message: Hello World\ncode: 200\n", w.Body.String())
 	})
 
 	t.Run("error", func(t *testing.T) {
 		errorWriter := &errorWriter{}
-		SendYAML(errorWriter, nil, response{Message: "Hello World", Code: http.StatusOK})
+		SendYAML(errorWriter, httptest.NewRequest("", "/", nil), response{Message: "Hello World", Code: http.StatusOK})
 		require.Contains(t, errorWriter.Arg, "Cannot serialize returned response to YAML")
 	})
 }
@@ -391,7 +391,7 @@ func TestSendJSON(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		errorWriter := &errorWriter{}
-		err := SendJSON(errorWriter, nil, response{Message: "Hello World", Code: http.StatusOK})
+		err := SendJSON(errorWriter, httptest.NewRequest("", "/", nil), response{Message: "Hello World", Code: http.StatusOK})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot write on an errorWriter")
 		require.JSONEq(t, "{\"message\":\"Hello World\",\"code\":200}\n", errorWriter.Arg)

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -220,7 +220,7 @@ func TestJSONError(t *testing.T) {
 
 	err := validate(me)
 	w := httptest.NewRecorder()
-	err = ErrorHandler(err)
+	err = ErrorHandler(context.Background(), err)
 	SendJSONError(w, nil, err)
 	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
 

--- a/serve.go
+++ b/serve.go
@@ -133,7 +133,7 @@ func Flow[B, T any](s *Engine, ctx ContextFlowable[B], controller func(c Context
 	// PARAMS VALIDATION
 	err := ValidateParams(ctx)
 	if err != nil {
-		err = s.ErrorHandler(err)
+		err = s.ErrorHandler(ctx, err)
 		ctx.SerializeError(err)
 		return
 	}
@@ -144,7 +144,7 @@ func Flow[B, T any](s *Engine, ctx ContextFlowable[B], controller func(c Context
 	// CONTROLLER
 	ans, err := controller(ctx)
 	if err != nil {
-		err = s.ErrorHandler(err)
+		err = s.ErrorHandler(ctx, err)
 		ctx.SerializeError(err)
 		return
 	}
@@ -160,7 +160,7 @@ func Flow[B, T any](s *Engine, ctx ContextFlowable[B], controller func(c Context
 	timeTransformOut := time.Now()
 	ans, err = transformOut(ctx.Context(), ans)
 	if err != nil {
-		err = s.ErrorHandler(err)
+		err = s.ErrorHandler(ctx, err)
 		ctx.SerializeError(err)
 		return
 	}
@@ -170,7 +170,7 @@ func Flow[B, T any](s *Engine, ctx ContextFlowable[B], controller func(c Context
 	// SERIALIZATION
 	err = ctx.Serialize(ans)
 	if err != nil {
-		err = s.ErrorHandler(err)
+		err = s.ErrorHandler(ctx, err)
 		ctx.SerializeError(err)
 	}
 	ctx.SetHeader("Server-Timing", Timing{"serialize", "", time.Since(timeAfterTransformOut)}.String())

--- a/serve_test.go
+++ b/serve_test.go
@@ -637,7 +637,7 @@ func TestFlow(t *testing.T) {
 		assert.Equal(t, crlf(`{"ans":"Hello World"}`), w.Body.String())
 	})
 	t.Run("with nil return in ErrorHandler", func(t *testing.T) {
-		e := NewEngine(WithErrorHandler(func(err error) error { return nil }))
+		e := NewEngine(WithErrorHandler(func(_ context.Context, err error) error { return nil }))
 		w := httptest.NewRecorder()
 		ctx := newTestCtx(w, httptest.NewRequest("GET", "/", nil))
 		Flow(e, ctx, testControllerWithError)

--- a/serve_test.go
+++ b/serve_test.go
@@ -644,6 +644,17 @@ func TestFlow(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 		assert.Equal(t, crlf(`null`), w.Body.String())
 	})
+	t.Run("ensure context is passed to ErrorHandler", func(t *testing.T) {
+		var receivedCtx context.Context
+		e := NewEngine(WithErrorHandler(func(ctx context.Context, err error) error {
+			receivedCtx = ctx
+			return nil
+		}))
+		w := httptest.NewRecorder()
+		ctx := newTestCtx(w, httptest.NewRequest("GET", "/", nil))
+		Flow(e, ctx, testControllerWithError)
+		assert.Equal(t, ctx, receivedCtx)
+	})
 	t.Run("transformOut error on value receiver", func(t *testing.T) {
 		e := NewEngine()
 		tcs := []struct {


### PR DESCRIPTION
Closes: #496 

BREAKING CHANGE: `ErrorHandler` signature is updated to also include context. 

This change allows callers too pass request scoped values to our log functions. The great thing about slog is that it allows you to bring your own logger. Slog even suggest to use [context functions](https://pkg.go.dev/log/slog#hdr-Contexts) when possible for this very reason. 

> It is recommended to pass a context to an output method if one is available.

Thanks