### PR TITLE
fix: add struct to log property not found log when parsing structTags

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -412,7 +412,7 @@ func parseStructTags(t reflect.Type, schemaRef *openapi3.SchemaRef) {
 
 		property := schemaRef.Value.Properties[jsonFieldName]
 		if property == nil {
-			slog.Warn("Property not found in schema", "property", jsonFieldName)
+			slog.Warn("Property not found in schema", "property", jsonFieldName, "struct", t.Name())
 			continue
 		}
 

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -293,7 +293,15 @@ func Test_tagFromType(t *testing.T) {
 		)
 
 		SchemaTagFromType(s.OpenAPI, InvalidExample{})
-		handler.AssertMessage("Property not found in schema")
+		handler.AssertPrecise(slogassert.LogMessageMatch{
+			Message:       "Property not found in schema",
+			Level:         slog.LevelWarn,
+			AllAttrsMatch: true,
+			Attrs: map[string]any{
+				"property": "XMLName",
+				"struct":   "InvalidExample",
+			},
+		})
 		handler.AssertMessage("Example might be incorrect (should be integer)")
 		handler.AssertMessage("Max might be incorrect (should be integer)")
 		handler.AssertMessage("Min might be incorrect (should be integer)")


### PR DESCRIPTION
At the struct name as a field. Couldn't really tell what structures it's referring too unless we have the struct name.