### PR TITLE
feat: allow custom content-type serdes for each endpoint

### DIFF
--- a/option.go
+++ b/option.go
@@ -470,6 +470,13 @@ func OptionDefaultStatusCode(defaultStatusCode int) func(*BaseRoute) {
 	}
 }
 
+// OptionWithContentTypeSerde sets a custom serializer and deserializer for a content type.
+func OptionWithContentTypeSerde(contentType string, serde Serde) func(*BaseRoute) {
+	return func(r *BaseRoute) {
+		r.contentTypeSerde[contentType] = serde
+	}
+}
+
 // OptionSecurity configures security requirements to the route.
 //
 // Single Scheme (AND Logic):

--- a/option/option.go
+++ b/option/option.go
@@ -201,3 +201,6 @@ var DefaultStatusCode = fuego.OptionDefaultStatusCode
 // StripTrailingSlash removes the trailing slash from the route.
 // By default, the trailing slash is kept, so becauseful when registering route like "/" within a group.
 var StripTrailingSlash = fuego.OptionStripTrailingSlash
+
+// WithContentTypeSerde sets a custom serializer and deserializer for a content type.
+var WithContentTypeSerde = fuego.OptionWithContentTypeSerde

--- a/route.go
+++ b/route.go
@@ -29,6 +29,7 @@ func NewBaseRoute(method, path string, handler any, e *Engine, options ...func(*
 		Operation:           openapi3.NewOperation(),
 		OpenAPI:             e.OpenAPI,
 		RequestContentTypes: e.requestContentTypes,
+		contentTypeSerde:    make(map[string]Serde),
 	}
 
 	for _, o := range options {
@@ -77,6 +78,9 @@ type BaseRoute struct {
 
 	// Middleware configuration for the route
 	MiddlewareConfig *MiddlewareConfig
+
+	// Serialization/deserialization for various content types for this route
+	contentTypeSerde map[string]Serde
 }
 
 func (r *BaseRoute) GenerateDefaultDescription() {

--- a/serdes.go
+++ b/serdes.go
@@ -1,0 +1,7 @@
+package fuego
+
+// Serde implements serialization and deserialization for a given type.
+type Serde interface {
+	Serialize(v any) ([]byte, error)
+	Deserialize(data []byte) (any, error)
+}


### PR DESCRIPTION
This PR adds support for a new Fuego endpoint `Option` to configure custom serialization and deserialization logic for specific content types.

Closes #516

If this general idea is agreeable, we could additionally refactor the current default content-type behaviors (`text/plain`, `application/json`, `application/xml`, etc.) from switch statements on `content-type` and `accept` headers to structs adhering to the `Serde` interface so that there is only one path to serialization/deserialization. I.e. `SendText()` ([link](https://github.com/go-fuego/fuego/blob/08392cc3224cbf58b305b11628845ae1106a28ee/serialization.go#L96)) and `readString()` ([link](https://github.com/go-fuego/fuego/blob/08392cc3224cbf58b305b11628845ae1106a28ee/ctx.go#L520)) become a `StringSerde{}` registered for `text/plain`.

Other notes:
- All of the `Read*()` methods ([link](https://github.com/go-fuego/fuego/blob/08392cc3224cbf58b305b11628845ae1106a28ee/deserialization.go#L42)) take `(ctx context.Context, input io.Reader, options readOptions)` args. Perhaps `Deserialize()` should adhere to this.
- All of the `Send*()` methods ([link](https://github.com/go-fuego/fuego/blob/08392cc3224cbf58b305b11628845ae1106a28ee/serialization.go#L157)) take `(w http.ResponseWriter, r *http.Request, ans any)` args. Perhaps `Serialize()` should adhere to this.
- Should this be configurable at the server level in addition to the endpoint level?
- Docs need updated