### PR TITLE
chore: remove trailing slash from adaptor swagger url

### DIFF
--- a/extra/fuegoecho/adaptor.go
+++ b/extra/fuegoecho/adaptor.go
@@ -21,7 +21,7 @@ func (o *OpenAPIHandler) UIHandler(e *fuego.Engine) {
 	GetEcho(
 		e,
 		o.Echo,
-		e.OpenAPI.Config.SwaggerURL+"/",
+		e.OpenAPI.Config.SwaggerURL,
 		echo.WrapHandler(e.OpenAPI.Config.UIHandler(e.OpenAPI.Config.SpecURL)),
 		fuego.OptionHide(),
 	)

--- a/extra/fuegogin/adaptor.go
+++ b/extra/fuegogin/adaptor.go
@@ -24,7 +24,7 @@ func (o *OpenAPIHandler) UIHandler(e *fuego.Engine) {
 	GetGin(
 		e,
 		o.GinEngine,
-		e.OpenAPI.Config.SwaggerURL+"/",
+		e.OpenAPI.Config.SwaggerURL,
 		gin.WrapH(e.OpenAPI.Config.UIHandler(e.OpenAPI.Config.SpecURL)),
 		fuego.OptionHide(),
 	)


### PR DESCRIPTION
Not sure why I ever added the trailing slash here to be honest. This does cause confusion like with #394 