### PR TITLE
Unused code in echo-compat

### DIFF
--- a/examples/echo-compat/handlers.go
+++ b/examples/echo-compat/handlers.go
@@ -36,12 +36,6 @@ func fuegoControllerPost(c fuego.ContextWithBody[HelloRequest]) (*HelloResponse,
 	}, nil
 }
 
-func serveOpenApiJSONDescription(s *fuego.OpenAPI) echo.HandlerFunc {
-	return func(ctx echo.Context) error {
-		return ctx.JSON(http.StatusOK, s.Description())
-	}
-}
-
 func DefaultOpenAPIHandler(specURL string) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
 		ctx.Response().Header().Set(echo.HeaderContentType, "text/html; charset=utf-8")

--- a/extra/fuegoecho/adaptor.go
+++ b/extra/fuegoecho/adaptor.go
@@ -21,7 +21,7 @@ func (o *OpenAPIHandler) UIHandler(e *fuego.Engine) {
 	GetEcho(
 		e,
 		o.Echo,
-		e.OpenAPI.Config.SwaggerURL+"/",
+		e.OpenAPI.Config.SwaggerURL,
 		echo.WrapHandler(e.OpenAPI.Config.UIHandler(e.OpenAPI.Config.SpecURL)),
 		fuego.OptionHide(),
 	)

--- a/extra/fuegogin/adaptor.go
+++ b/extra/fuegogin/adaptor.go
@@ -24,7 +24,7 @@ func (o *OpenAPIHandler) UIHandler(e *fuego.Engine) {
 	GetGin(
 		e,
 		o.GinEngine,
-		e.OpenAPI.Config.SwaggerURL+"/",
+		e.OpenAPI.Config.SwaggerURL,
 		gin.WrapH(e.OpenAPI.Config.UIHandler(e.OpenAPI.Config.SpecURL)),
 		fuego.OptionHide(),
 	)


### PR DESCRIPTION
left over from when we switched over to the `engine.RegisterOpenAPIRoutes`