### PR TITLE
feat: update OptionRequestBody to allow for multiple request bodies in spec

### DIFF
--- a/examples/petstore/controllers/pets.go
+++ b/examples/petstore/controllers/pets.go
@@ -62,6 +62,12 @@ func (rs PetsResources) Routes(s *fuego.Server) {
 	)
 	fuego.Post(petsGroup, "/", rs.postPets,
 		option.DefaultStatusCode(201),
+		option.RequestBody(fuego.RequestBody{
+			Type: models.PetsCreate{}, ContentTypes: []string{"custom-content-type", "and-another"},
+		}),
+		option.RequestBody(fuego.RequestBody{
+			Type: models.Pets{}, ContentTypes: []string{"different-type"},
+		}),
 		option.AddResponse(409, "Conflict: Pet with the same name already exists", fuego.Response{Type: PetsError{}}),
 	)
 

--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -621,9 +621,19 @@
 				],
 				"requestBody": {
 					"content": {
-						"*/*": {
+						"and-another": {
 							"schema": {
 								"$ref": "#/components/schemas/PetsCreate"
+							}
+						},
+						"custom-content-type": {
+							"schema": {
+								"$ref": "#/components/schemas/PetsCreate"
+							}
+						},
+						"different-type": {
+							"schema": {
+								"$ref": "#/components/schemas/Pets"
 							}
 						}
 					},

--- a/param.go
+++ b/param.go
@@ -1,6 +1,6 @@
 package fuego
 
-// A ParamOption configures OpenAPI properties of an OpenAPI Param
+// A ParamOption configures OpenAPI properties of [OpenAPIParam]
 // i.e path/query parameters, cookies, and headers
 type ParamOption = func(param *OpenAPIParam)
 


### PR DESCRIPTION
Add a use for this today.

Also this can provide a caller a way to gen proper types of spec #524 in cases where the content-type specified could cause the route to deserialize a different type altogether.  