### PR TITLE
fix(validation.go): prevent panic when validate is called with nil

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -32,7 +32,8 @@ func explainError(err validator.FieldError) string {
 var v = validator.New()
 
 func validate(a any) error {
-	if reflect.TypeOf(a).Kind() != reflect.Struct {
+	t := reflect.TypeOf(a)
+	if t == nil || t.Kind() != reflect.Struct {
 		return nil
 	}
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -16,25 +16,32 @@ type validatableStruct struct {
 }
 
 func TestValidate(t *testing.T) {
-	me := validatableStruct{
-		Name:  "Napoleon Bonaparte",
-		Age:   12,
-		Email: "napoleon.bonaparte",
-	}
+	t.Run("nil input", func(t *testing.T) {
+		err := validate(nil)
+		t.Log(err)
+		require.NoError(t, err)
+	})
 
-	err := validate(me)
-	t.Log(err)
-	require.Error(t, err)
+	t.Run("struct with errors", func(t *testing.T) {
+		me := validatableStruct{
+			Name:  "Napoleon Bonaparte",
+			Age:   12,
+			Email: "napoleon.bonaparte",
+		}
+		err := validate(me)
+		t.Log(err)
+		require.Error(t, err)
 
-	var errStructValidation HTTPError
-	require.ErrorAs(t, err, &errStructValidation)
-	assert.Equal(t, 400, errStructValidation.Status)
-	assert.Equal(t, "Validation Error", errStructValidation.Title)
-	assert.Len(t, errStructValidation.Errors, 5)
-	assert.Equal(t, "400 Validation Error (Name should be max=10, Age should be min=18, Required is required, Email should be a valid email, ExternalID should be a valid UUID)", errStructValidation.PublicError())
-	assert.EqualError(t, errStructValidation, `400 Validation Error (Name should be max=10, Age should be min=18, Required is required, Email should be a valid email, ExternalID should be a valid UUID): Key: 'validatableStruct.Name' Error:Field validation for 'Name' failed on the 'max' tag
+		var errStructValidation HTTPError
+		require.ErrorAs(t, err, &errStructValidation)
+		assert.Equal(t, 400, errStructValidation.Status)
+		assert.Equal(t, "Validation Error", errStructValidation.Title)
+		assert.Len(t, errStructValidation.Errors, 5)
+		assert.Equal(t, "400 Validation Error (Name should be max=10, Age should be min=18, Required is required, Email should be a valid email, ExternalID should be a valid UUID)", errStructValidation.PublicError())
+		assert.EqualError(t, errStructValidation, `400 Validation Error (Name should be max=10, Age should be min=18, Required is required, Email should be a valid email, ExternalID should be a valid UUID): Key: 'validatableStruct.Name' Error:Field validation for 'Name' failed on the 'max' tag
 Key: 'validatableStruct.Age' Error:Field validation for 'Age' failed on the 'min' tag
 Key: 'validatableStruct.Required' Error:Field validation for 'Required' failed on the 'required' tag
 Key: 'validatableStruct.Email' Error:Field validation for 'Email' failed on the 'email' tag
 Key: 'validatableStruct.ExternalID' Error:Field validation for 'ExternalID' failed on the 'uuid' tag`)
+	})
 }


### PR DESCRIPTION
I have a route that wants to accept any valid JSON. I implemented this with `fuego.ContextWithBody[any]`. 
When posting no request body or the literal `null` to this route the thread silently panics and I never get a response, only a client error "Connection was forcibly closed by a peer." I don't think this should happen under any circumstance.

I have tracked down and fixed the panicking code but have since also read the doc string for `ContextWithBody` that says "Please do not use a pointer type as parameters.". Wouldn't it be okay to use `any`? Would it lead to inconsistencies if my change got implemented? With my change I simply get a `nil` body. 

The auto-generated OpenAPI spec looks like this, which is okay for my usecase:
<img width="389" height="222" alt="image" src="https://github.com/user-attachments/assets/eb991d2e-34c5-4aad-99ae-15d36ac7bc9c" />
