### PR TITLE
Fix custom ui example in docs

### DIFF
--- a/documentation/docs/guides/openapi.md
+++ b/documentation/docs/guides/openapi.md
@@ -166,7 +166,8 @@ import (
 	"net/http"
 
 	"github.com/go-fuego/fuego"
-	httpSwagger "github.com/swaggo/http-swagger"
+	httpSwagger "github.com/swaggo/http-swagger/v2"
+	// For older OpenAPI versions, use "github.com/swaggerapi/http-swagger" instead.
 )
 
 func openApiHandler(specURL string) http.Handler {


### PR DESCRIPTION
The docs custom ui example did not work with the latest fuego version because of a version mismatch of the openapi specs.

More here: https://github.com/go-fuego/fuego/issues/579