### PR TITLE
feat: add OpenAPIConfig.SwaggerMiddlewares option to apply middlewares to swagger routes

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -69,6 +69,9 @@ type OpenAPIConfig struct {
 	UIHandler func(specURL string) http.Handler
 	// URL to serve the swagger UI
 	SwaggerURL string
+	// SwaggerMiddlewares applies desired middleware to routes
+	// associated with [OpenAPIConfig.SpecURL] and [OpenAPIConfig.SwaggerURL]
+	SwaggerMiddlewares []func(http.Handler) http.Handler
 	// If true, the server will not serve the Swagger UI
 	DisableSwaggerUI bool
 	// Middleware configuration for the engine
@@ -149,6 +152,7 @@ func WithOpenAPIConfig(config OpenAPIConfig) EngineOption {
 		e.OpenAPI.Config.PrettyFormatJSON = config.PrettyFormatJSON
 		e.OpenAPI.Config.DisableSwaggerUI = config.DisableSwaggerUI
 		e.OpenAPI.Config.DisableMessages = config.DisableMessages
+		e.OpenAPI.Config.SwaggerMiddlewares = config.SwaggerMiddlewares
 
 		if !validateSpecURL(e.OpenAPI.Config.SpecURL) {
 			slog.Error("Error serving OpenAPI JSON spec. Value of 's.OpenAPIServerConfig.SpecURL' option is not valid", "url", e.OpenAPI.Config.SpecURL)

--- a/extra/fuegoecho/adaptor.go
+++ b/extra/fuegoecho/adaptor.go
@@ -14,7 +14,7 @@ type OpenAPIHandler struct {
 }
 
 func (o *OpenAPIHandler) SpecHandler(e *fuego.Engine) {
-	Get(e, o.Echo, e.OpenAPI.Config.SpecURL, e.SpecHandler(), fuego.OptionHide())
+	Get(e, o.Echo, e.OpenAPI.Config.SpecURL, e.SpecHandler(), fuego.OptionHide(), fuego.OptionMiddleware(e.OpenAPI.Config.SwaggerMiddlewares...))
 }
 
 func (o *OpenAPIHandler) UIHandler(e *fuego.Engine) {
@@ -24,6 +24,7 @@ func (o *OpenAPIHandler) UIHandler(e *fuego.Engine) {
 		e.OpenAPI.Config.SwaggerURL,
 		echo.WrapHandler(e.OpenAPI.Config.UIHandler(e.OpenAPI.Config.SpecURL)),
 		fuego.OptionHide(),
+		fuego.OptionMiddleware(e.OpenAPI.Config.SwaggerMiddlewares...),
 	)
 }
 

--- a/extra/fuegogin/adaptor.go
+++ b/extra/fuegogin/adaptor.go
@@ -17,7 +17,7 @@ type OpenAPIHandler struct {
 }
 
 func (o *OpenAPIHandler) SpecHandler(e *fuego.Engine) {
-	Get(e, o.GinEngine, e.OpenAPI.Config.SpecURL, e.SpecHandler(), fuego.OptionHide())
+	Get(e, o.GinEngine, e.OpenAPI.Config.SpecURL, e.SpecHandler(), fuego.OptionHide(), fuego.OptionMiddleware(e.OpenAPI.Config.SwaggerMiddlewares...))
 }
 
 func (o *OpenAPIHandler) UIHandler(e *fuego.Engine) {
@@ -27,6 +27,7 @@ func (o *OpenAPIHandler) UIHandler(e *fuego.Engine) {
 		e.OpenAPI.Config.SwaggerURL,
 		gin.WrapH(e.OpenAPI.Config.UIHandler(e.OpenAPI.Config.SpecURL)),
 		fuego.OptionHide(),
+		fuego.OptionMiddleware(e.OpenAPI.Config.SwaggerMiddlewares...),
 	)
 }
 

--- a/server.go
+++ b/server.go
@@ -147,12 +147,12 @@ func NewServer(options ...ServerOption) *Server {
 }
 
 func (s *Server) SpecHandler(_ *Engine) {
-	Get(s, s.OpenAPI.Config.SpecURL, s.Engine.SpecHandler(), OptionHide())
+	Get(s, s.OpenAPI.Config.SpecURL, s.Engine.SpecHandler(), OptionHide(), OptionMiddleware(s.OpenAPI.Config.SwaggerMiddlewares...))
 	s.printOpenAPIMessage(fmt.Sprintf("JSON spec: %s%s", s.url(), s.OpenAPI.Config.SpecURL))
 }
 
 func (s *Server) UIHandler(_ *Engine) {
-	GetStd(s, s.OpenAPI.Config.SwaggerURL+"/", s.OpenAPI.Config.UIHandler(s.OpenAPI.Config.SpecURL).ServeHTTP, OptionHide())
+	GetStd(s, s.OpenAPI.Config.SwaggerURL+"/", s.OpenAPI.Config.UIHandler(s.OpenAPI.Config.SpecURL).ServeHTTP, OptionHide(), OptionMiddleware(s.OpenAPI.Config.SwaggerMiddlewares...))
 	s.printOpenAPIMessage(fmt.Sprintf("OpenAPI UI: %s%s/index.html", s.url(), s.OpenAPI.Config.SwaggerURL))
 }
 


### PR DESCRIPTION
Closes #599 

Noticed this the other day. Currently the only way to do this is to create your own routes entirely. This makes it's much easier to pass in say authentication middleware when accessing these routes.