### PR TITLE
feat: provide the ability to set http.Request in MockContext

### DIFF
--- a/mock_context.go
+++ b/mock_context.go
@@ -107,6 +107,10 @@ func (m *MockContext[B, P]) PathParamInt(name string) int {
 	return 0
 }
 
+func (m *MockContext[B, P]) SetRequest(r *http.Request) {
+	m.request = r
+}
+
 // Request returns the mock request
 func (m *MockContext[B, P]) Request() *http.Request {
 	return m.request

--- a/mock_context_test.go
+++ b/mock_context_test.go
@@ -2,6 +2,7 @@ package fuego_test
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -193,5 +194,26 @@ func TestMockContextNoBody(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, "Hello, ", response)
+	})
+}
+
+func Test_SetRequest(t *testing.T) {
+	t.Run("base", func(t *testing.T) {
+		ctx := fuego.NewMockContextNoBody()
+		req, err := http.NewRequest(http.MethodGet, "/test?foo=bar", nil)
+		require.NoError(t, err)
+
+		ctx.SetRequest(req)
+
+		retrievedReq := ctx.Request()
+		require.NotNil(t, retrievedReq)
+		assert.Equal(t, http.MethodGet, retrievedReq.Method)
+		assert.Equal(t, "/test?foo=bar", retrievedReq.URL.String())
+	})
+
+	t.Run("request should be nil", func(t *testing.T) {
+		ctx := fuego.NewMockContextNoBody()
+		r := ctx.Request()
+		require.Nil(t, r)
 	})
 }


### PR DESCRIPTION
closes #568

Elected to go with SetRequest instead of in the constructor. Making the field public is not an option as it has to adhere to the Context interface.