### PR TITLE
fix: allow use of echo path format

### DIFF
--- a/extra/fuegoecho/adaptor.go
+++ b/extra/fuegoecho/adaptor.go
@@ -2,12 +2,15 @@ package fuegoecho
 
 import (
 	"net/http"
+	"regexp"
 
 	"github.com/labstack/echo/v4"
 
 	"github.com/go-fuego/fuego"
 	"github.com/go-fuego/fuego/internal"
 )
+
+var pathRegex = regexp.MustCompile(`:([a-zA-Z0-9_]+)`)
 
 type OpenAPIHandler struct {
 	Echo *echo.Echo
@@ -98,36 +101,48 @@ func Delete[T, B, P any](engine *fuego.Engine, echoRouter echoIRouter, path stri
 }
 
 func handleFuego[T, B, P any](engine *fuego.Engine, echoRouter echoIRouter, method, path string, fuegoHandler func(c fuego.Context[B, P]) (T, error), options ...func(*fuego.BaseRoute)) *fuego.Route[T, B, P] {
-	baseRoute := fuego.NewBaseRoute(method, path, fuegoHandler, engine, options...)
+	baseRoute := fuego.NewBaseRoute(method, echoToFuegoRoute(path), fuegoHandler, engine, options...)
 	return fuego.Registers(engine, echoRouteRegisterer[T, B, P]{
-		echoRouter:  echoRouter,
-		route:       fuego.Route[T, B, P]{BaseRoute: baseRoute},
-		echoHandler: EchoHandler(engine, fuegoHandler, baseRoute),
+		echoRouter:   echoRouter,
+		route:        fuego.Route[T, B, P]{BaseRoute: baseRoute},
+		echoHandler:  EchoHandler(engine, fuegoHandler, baseRoute),
+		originalPath: path,
 	})
 }
 
 func handleEcho(engine *fuego.Engine, echoRouter echoIRouter, method, path string, echoHandler echo.HandlerFunc, options ...func(*fuego.BaseRoute)) *fuego.Route[any, any, any] {
-	baseRoute := fuego.NewBaseRoute(method, path, echoHandler, engine, options...)
+	baseRoute := fuego.NewBaseRoute(method, echoToFuegoRoute(path), echoHandler, engine, options...)
 	return fuego.Registers(engine, echoRouteRegisterer[any, any, any]{
-		echoRouter:  echoRouter,
-		route:       fuego.Route[any, any, any]{BaseRoute: baseRoute},
-		echoHandler: echoHandler,
+		echoRouter:   echoRouter,
+		route:        fuego.Route[any, any, any]{BaseRoute: baseRoute},
+		echoHandler:  echoHandler,
+		originalPath: path,
 	})
 }
 
+func echoToFuegoRoute(path string) string {
+	return pathRegex.ReplaceAllString(path, `{$1}`)
+}
+
 type echoRouteRegisterer[T, B, P any] struct {
-	echoRouter  echoIRouter
-	echoHandler echo.HandlerFunc
-	route       fuego.Route[T, B, P]
+	echoRouter   echoIRouter
+	echoHandler  echo.HandlerFunc
+	route        fuego.Route[T, B, P]
+	originalPath string
 }
 
 func (a echoRouteRegisterer[T, B, P]) Register() fuego.Route[T, B, P] {
-	route := a.echoRouter.Add(a.route.Method, a.route.Path, a.echoHandler)
-	a.route.Path = route.Path
+	// We must register the echo handler first, so that the echo router can
+	// mutate the route path if it is a Group.
+	// This is because echo groups will prepend the group prefix to the route path itself.
+	route := a.echoRouter.Add(a.route.Method, a.originalPath, a.echoHandler)
+	// Echo returns the full path with group prefix, convert it to Fuego format
+	a.route.Path = echoToFuegoRoute(route.Path)
+
 	return a.route
 }
 
-// Convert a Fuego handler to a Gin handler.
+// Convert a Fuego handler to an echo handler.
 func EchoHandler[B, T, P any](engine *fuego.Engine, handler func(c fuego.Context[B, P]) (T, error), route fuego.BaseRoute) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		context := &echoContext[B, P]{

--- a/extra/fuegoecho/adaptor_test.go
+++ b/extra/fuegoecho/adaptor_test.go
@@ -1,0 +1,56 @@
+package fuegoecho
+
+import (
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-fuego/fuego"
+	"github.com/go-fuego/fuego/option"
+)
+
+func TestFuegoPathWithEchoPathParam(t *testing.T) {
+	basePath := "/api"
+	apiPath := "/path/:id"
+	e := fuego.NewEngine()
+	echoRouter := echo.New()
+	group := echoRouter.Group(basePath)
+
+	Get(e, group, apiPath, func(c fuego.Context[any, any]) (string, error) { return "ok", nil },
+		option.Path("id", "ID"),
+	)
+
+	spec := e.OutputOpenAPISpec()
+	specPath := spec.Paths.Find("/api/path/{id}")
+
+	routes := echoRouter.Routes()
+	assert.Len(t, routes, 1, "Expected exactly one route registered in Echo")
+	assert.Equal(t, routes[0].Path, basePath+apiPath)
+
+	assert.NotNil(t, specPath,
+		"Expected path '/api/path/{id}' to be registered in OpenAPI spec")
+}
+
+func TestFuegoPathWithTwoEchoPathParams(t *testing.T) {
+	basePath := "/api"
+	apiPath := "/path/:id1/foo/:id2"
+	e := fuego.NewEngine()
+	echoRouter := echo.New()
+	group := echoRouter.Group(basePath)
+
+	Get(e, group, apiPath, func(c fuego.Context[any, any]) (string, error) { return "ok", nil },
+		option.Path("id1", "First ID"),
+		option.Path("id2", "Second ID"),
+	)
+
+	spec := e.OutputOpenAPISpec()
+	specPath := spec.Paths.Find("/api/path/{id1}/foo/{id2}")
+
+	routes := echoRouter.Routes()
+	assert.Len(t, routes, 1, "Expected exactly one route registered in Echo")
+	assert.Equal(t, routes[0].Path, basePath+apiPath)
+
+	assert.NotNil(t, specPath,
+		"Expected path '/api/path/{id1}/foo/{id2}' to be registered in OpenAPI spec")
+}


### PR DESCRIPTION
port of b5670a2345767293f7f9621b501713a0c7a34400 / https://github.com/go-fuego/fuego/pull/449

Fixes a panic when route contains `:foo` and a corresponding `option.Path("foo", "The Foo")`:

```
panic: path parameter 'foo' is declared in OpenAPI but not on the route

goroutine 1 [running]:
```