### PR TITLE
fix: always pass request to Senders and we use the request context in it's log

### DIFF
--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -42,7 +42,7 @@ func New(config Config) func(http.Handler) http.Handler {
 			}
 
 			w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
-			fuego.SendJSONError(w, nil, err)
+			fuego.SendJSONError(w, r, err)
 		})
 	}
 }

--- a/security.go
+++ b/security.go
@@ -230,7 +230,7 @@ func (security Security) TokenToContext(searchFunc ...func(*http.Request) string
 			// Validate the token
 			t, err := security.ValidateToken(token)
 			if err != nil {
-				SendJSONError(w, nil, err)
+				SendJSONError(w, r, err)
 				return
 			}
 
@@ -318,20 +318,20 @@ func authWall(authorizeFunc func(userRoles ...string) bool) func(next http.Handl
 			// Get the authorizationHeader from the context (set by TokenToContext)
 			claims, err := TokenFromContext(r.Context())
 			if err != nil {
-				SendJSONError(w, nil, UnauthorizedError{Title: "Unauthorized"})
+				SendJSONError(w, r, UnauthorizedError{Title: "Unauthorized"})
 				return
 			}
 
 			// Get the subject and userRoles from the claims
 			userRoles, ok := claims.(jwt.MapClaims)["roles"].([]string)
 			if !ok {
-				SendJSONError(w, nil, UnauthorizedError{Title: "Could not find roles in token"})
+				SendJSONError(w, r, UnauthorizedError{Title: "Could not find roles in token"})
 				return
 			}
 
 			// Check if the user is authorized
 			if !authorizeFunc(userRoles...) {
-				SendJSONError(w, nil, ForbiddenError{Title: "Access denied"})
+				SendJSONError(w, r, ForbiddenError{Title: "Access denied"})
 				return
 			}
 
@@ -381,14 +381,14 @@ func (security Security) StdLoginHandler(verifyUserInfo func(r *http.Request) (j
 	return func(w http.ResponseWriter, r *http.Request) {
 		claims, err := verifyUserInfo(r)
 		if err != nil {
-			SendJSONError(w, nil, err)
+			SendJSONError(w, r, err)
 			return
 		}
 
 		// Send the token to the cookies
 		token, err := security.GenerateTokenToCookies(claims, w)
 		if err != nil {
-			SendJSONError(w, nil, err)
+			SendJSONError(w, r, err)
 			return
 		}
 
@@ -476,14 +476,14 @@ func (security Security) LoginHandler(verifyUserInfo func(user, password string)
 func (security Security) RefreshHandler(w http.ResponseWriter, r *http.Request) {
 	claims, err := TokenFromContext(r.Context())
 	if err != nil {
-		SendJSONError(w, nil, UnauthorizedError{Title: "Could not find token in context"})
+		SendJSONError(w, r, UnauthorizedError{Title: "Could not find token in context"})
 		return
 	}
 
 	// Send the token to the cookies
 	token, err := security.GenerateTokenToCookies(claims, w)
 	if err != nil {
-		SendJSONError(w, nil, err)
+		SendJSONError(w, r, err)
 		return
 	}
 

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -233,7 +233,7 @@ func TestJSONError(t *testing.T) {
 	err := validate(me)
 	w := httptest.NewRecorder()
 	err = ErrorHandler(context.Background(), err)
-	SendJSONError(w, nil, err)
+	SendJSONError(w, httptest.NewRequest("", "/", nil), err)
 	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
 
 	require.JSONEq(t, `
@@ -304,7 +304,7 @@ func TestJSONError(t *testing.T) {
 
 func TestSendText(t *testing.T) {
 	w := httptest.NewRecorder()
-	SendText(w, nil, "Hello World")
+	SendText(w, httptest.NewRequest("", "/", nil), "Hello World")
 
 	require.Equal(t, "Hello World", w.Body.String())
 }
@@ -312,7 +312,7 @@ func TestSendText(t *testing.T) {
 func TestSendTextError(t *testing.T) {
 	t.Run("base", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendTextError(w, nil, errors.New("Hello World"))
+		SendTextError(w, httptest.NewRequest("", "/", nil), errors.New("Hello World"))
 
 		assert.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
 		assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
@@ -320,7 +320,7 @@ func TestSendTextError(t *testing.T) {
 	})
 	t.Run("error with status", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendTextError(w, nil, BadRequestError{Err: errors.New("Hello World")})
+		SendTextError(w, httptest.NewRequest("", "/", nil), BadRequestError{Err: errors.New("Hello World")})
 		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
 		assert.Equal(t, "400 Bad Request", w.Body.String())
@@ -360,7 +360,7 @@ func TestSendYAML(t *testing.T) {
 func TestSendYAMLError(t *testing.T) {
 	t.Run("base", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendYAMLError(w, nil, errors.New("Hello World"))
+		SendYAMLError(w, httptest.NewRequest("", "/", nil), errors.New("Hello World"))
 
 		require.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
 		require.Equal(t, "application/x-yaml", w.Header().Get("Content-Type"))
@@ -375,14 +375,14 @@ func TestSendYAMLError(t *testing.T) {
 	})
 	t.Run("error with status and detail", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendYAMLError(w, nil, BadRequestError{Err: errors.New("Hello World"), Detail: "World, Hello"})
+		SendYAMLError(w, httptest.NewRequest("", "/", nil), BadRequestError{Err: errors.New("Hello World"), Detail: "World, Hello"})
 		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		require.Equal(t, "application/x-yaml", w.Header().Get("Content-Type"))
 		require.Equal(t, crlf(`detail: World, Hello`), w.Body.String())
 	})
 	t.Run("error with multiple fields", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendYAMLError(w, nil, BadRequestError{
+		SendYAMLError(w, httptest.NewRequest("", "/", nil), BadRequestError{
 			Err:    errors.New("Hello World"),
 			Detail: "World, Hello",
 			Title:  "Error: Hello, World",
@@ -448,7 +448,7 @@ func TestSendHTML(t *testing.T) {
 
 	t.Run("Renderer", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		err := SendHTML(w, nil, &testRenderer{})
+		err := SendHTML(w, httptest.NewRequest("", "/", nil), &testRenderer{})
 		require.NoError(t, err)
 		require.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 		require.Equal(t, "hello", w.Body.String())
@@ -456,7 +456,7 @@ func TestSendHTML(t *testing.T) {
 
 	t.Run("HTML", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		err := SendHTML(w, nil, HTML("hello"))
+		err := SendHTML(w, httptest.NewRequest("", "/", nil), HTML("hello"))
 		require.NoError(t, err)
 		require.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 		require.Equal(t, "hello", w.Body.String())
@@ -464,7 +464,7 @@ func TestSendHTML(t *testing.T) {
 
 	t.Run("string", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		err := SendHTML(w, nil, "hello")
+		err := SendHTML(w, httptest.NewRequest("", "/", nil), "hello")
 		require.NoError(t, err)
 		require.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 		require.Equal(t, "hello", w.Body.String())
@@ -472,7 +472,7 @@ func TestSendHTML(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		err := SendHTML(w, nil, struct{}{})
+		err := SendHTML(w, httptest.NewRequest("", "/", nil), struct{}{})
 		require.Error(t, err)
 		require.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 	})
@@ -481,7 +481,7 @@ func TestSendHTML(t *testing.T) {
 func TestSendHTMLError(t *testing.T) {
 	t.Run("base", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendHTMLError(w, nil, errors.New("Hello World"))
+		SendHTMLError(w, httptest.NewRequest("", "/", nil), errors.New("Hello World"))
 
 		require.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
 		require.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
@@ -489,7 +489,7 @@ func TestSendHTMLError(t *testing.T) {
 	})
 	t.Run("error with status", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		SendHTMLError(w, nil, BadRequestError{Title: "My Error", Detail: "Greeting the world didn't work", Err: errors.New("Hello World failed")})
+		SendHTMLError(w, httptest.NewRequest("", "/", nil), BadRequestError{Title: "My Error", Detail: "Greeting the world didn't work", Err: errors.New("Hello World failed")})
 		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		require.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 		require.Equal(t, "400 My Error (Greeting the world didn't work)", w.Body.String())

--- a/tests_test.go
+++ b/tests_test.go
@@ -16,7 +16,7 @@ func TestContentType(t *testing.T) {
 
 	t.Run("Sends application/problem+json when return type is HTTPError", func(t *testing.T) {
 		GetStd(server, "/json-problems", func(w http.ResponseWriter, r *http.Request) {
-			SendJSONError(w, nil, UnauthorizedError{
+			SendJSONError(w, r, UnauthorizedError{
 				Title: "Unauthorized",
 			})
 		})
@@ -32,7 +32,7 @@ func TestContentType(t *testing.T) {
 
 	t.Run("Sends application/json when return type is not HTTPError", func(t *testing.T) {
 		GetStd(server, "/json", func(w http.ResponseWriter, r *http.Request) {
-			SendJSONError(w, nil, errors.New("error"))
+			SendJSONError(w, r, errors.New("error"))
 		})
 
 		req := httptest.NewRequest("GET", "/json", nil)


### PR DESCRIPTION
Closes #671 

SendHTML and SendText actually don't need to be update, but i'd rather be verbose here.