### PR TITLE
Allow passing options to SetGeneratorSchemaCustomizer

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -164,9 +164,9 @@ func WithOpenAPIConfig(config OpenAPIConfig) EngineOption {
 }
 
 // WithOpenAPIGeneratorConfig sets the options for the generator.
-func WithOpenAPIGeneratorSchemaCustomizer(sc openapi3gen.SchemaCustomizerFn) EngineOption {
+func WithOpenAPIGeneratorSchemaCustomizer(sc openapi3gen.SchemaCustomizerFn, options ...openapi3gen.Option) EngineOption {
 	return func(e *Engine) {
-		e.OpenAPI.SetGeneratorSchemaCustomizer(sc)
+		e.OpenAPI.SetGeneratorSchemaCustomizer(sc, options...)
 	}
 }
 

--- a/openapi.go
+++ b/openapi.go
@@ -41,15 +41,18 @@ func (openAPI *OpenAPI) Generator() *openapi3gen.Generator {
 }
 
 // Sets the openapi generator with a custom schema customizer function.
-func (openAPI *OpenAPI) SetGeneratorSchemaCustomizer(sc openapi3gen.SchemaCustomizerFn) {
+func (openAPI *OpenAPI) SetGeneratorSchemaCustomizer(sc openapi3gen.SchemaCustomizerFn, options ...openapi3gen.Option) {
 	// Create a function with the default schema customizer, and one with the provided, thereby merging the two.
 	customizerFn := func(name string, t reflect.Type, tag reflect.StructTag, schema *openapi3.Schema) error {
 		if err := SchemaCustomizer(name, t, tag, schema); err != nil {
 			return err
 		}
+		if sc == nil {
+			return nil
+		}
 		return sc(name, t, tag, schema)
 	}
-	openAPI.generator = openapi3gen.NewGenerator(openapi3gen.SchemaCustomizer(customizerFn))
+	openAPI.generator = openapi3gen.NewGenerator(append(options, openapi3gen.SchemaCustomizer(customizerFn))...)
 }
 
 func (openAPI *OpenAPI) mergeInfo(info *openapi3.Info) {


### PR DESCRIPTION
Fixed #519 

The issue was fixed upstream in https://github.com/getkin/kin-openapi/pull/1052.
This PR allows us to pass the `ExportComponentSchemas` option from fuego like this:

```go
	s := fuego.NewServer(
		fuego.WithAddr("0.0.0.0:8080"),
		fuego.WithEngineOptions(
			fuego.WithOpenAPIConfig(fuego.OpenAPIConfig{
				SpecURL:    "/api/v1/swagger/openapi.json",
				SwaggerURL: "/api/v1/swagger",
			}),
			fuego.WithOpenAPIGeneratorSchemaCustomizer(nil, openapi3gen.CreateComponentSchemas(openapi3gen.ExportComponentSchemasOptions{
				ExportComponentSchemas: true,
			})),
		),
	)
```