### PR TITLE
fix: sanitize all invalid characters in transformTypeName

### DIFF
--- a/examples/petstore/controllers/pets.go
+++ b/examples/petstore/controllers/pets.go
@@ -60,6 +60,10 @@ func (rs PetsResources) Routes(s *fuego.Server) {
 		option.Description("Get all pets in a generic wrapped response with a slice type parameter"),
 	)
 
+	fuego.Get(petsGroup, "/nested-wrapped", rs.getNestedWrapped,
+		option.Description("Get a pet in a nested generic response"),
+	)
+
 	fuego.Get(petsGroup, "/by-age", rs.getAllPetsByAge,
 		option.Description("Returns an array of pets grouped by age"),
 		option.Middleware(dummyMiddleware),
@@ -144,6 +148,23 @@ func (rs PetsResources) getAllPetsWrapped(c fuego.ContextNoBody) (*models.BareSu
 		StatusCode: 200,
 		Result:     pets,
 		Message:    "success",
+	}, nil
+}
+
+func (rs PetsResources) getNestedWrapped(c fuego.ContextNoBody) (*models.BareSuccessResponse[models.BareSuccessResponse[models.Pets]], error) {
+	pet, err := rs.PetsService.GetPets("1")
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.BareSuccessResponse[models.BareSuccessResponse[models.Pets]]{
+		StatusCode: 200,
+		Result: models.BareSuccessResponse[models.Pets]{
+			StatusCode: 200,
+			Result:     pet,
+			Message:    "inner",
+		},
+		Message: "outer",
 	}, nil
 }
 

--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -97,6 +97,115 @@
 				],
 				"type": "object"
 			},
+			"BareSuccessResponse_models.BareSuccessResponse-models.Pets": {
+				"description": "BareSuccessResponse_models.BareSuccessResponse-models.Pets schema",
+				"properties": {
+					"message": {
+						"type": "string"
+					},
+					"result": {
+						"properties": {
+							"message": {
+								"type": "string"
+							},
+							"result": {
+								"properties": {
+									"age": {
+										"description": "Age of the pet, in years",
+										"example": 2,
+										"type": "integer"
+									},
+									"birth_date": {
+										"format": "date-time",
+										"type": "string"
+									},
+									"id": {
+										"example": "pet-123456",
+										"type": "string"
+									},
+									"is_adopted": {
+										"description": "Is the pet adopted",
+										"type": "boolean"
+									},
+									"name": {
+										"example": "Napoleon",
+										"type": "string"
+									},
+									"references": {
+										"properties": {
+											"type": {
+												"description": "type of reference",
+												"example": "pet-123456",
+												"type": "string"
+											},
+											"value": {
+												"type": "string"
+											}
+										},
+										"required": [
+											"type",
+											"value"
+										],
+										"type": "object"
+									},
+									"treats": {
+										"items": {
+											"properties": {
+												"brand": {
+													"description": "The brand of the treat",
+													"type": "string"
+												},
+												"itemId": {
+													"description": "The unique id of the treat",
+													"format": "uuid",
+													"type": "string"
+												},
+												"name": {
+													"description": "the name of a treat",
+													"type": "string"
+												}
+											},
+											"required": [
+												"itemId",
+												"name"
+											],
+											"type": "object"
+										},
+										"type": "array"
+									}
+								},
+								"required": [
+									"age",
+									"birth_date",
+									"id",
+									"is_adopted",
+									"name",
+									"references"
+								],
+								"type": "object"
+							},
+							"statusCode": {
+								"type": "integer"
+							}
+						},
+						"required": [
+							"message",
+							"result",
+							"statusCode"
+						],
+						"type": "object"
+					},
+					"statusCode": {
+						"type": "integer"
+					}
+				},
+				"required": [
+					"message",
+					"result",
+					"statusCode"
+				],
+				"type": "object"
+			},
 			"BareSuccessResponse_models.Pets": {
 				"description": "BareSuccessResponse_models.Pets schema",
 				"properties": {
@@ -1513,6 +1622,98 @@
 					}
 				},
 				"summary": "Update a pet with JSON-only body",
+				"tags": [
+					"pets"
+				]
+			}
+		},
+		"/pets/nested-wrapped": {
+			"get": {
+				"description": "#### Controller: \n\n`github.com/go-fuego/fuego/examples/petstore/controllers.PetsResources.getNestedWrapped`\n\n#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\nGet a pet in a nested generic response",
+				"operationId": "GET_/pets/nested-wrapped",
+				"parameters": [
+					{
+						"description": "header description",
+						"in": "header",
+						"name": "X-Header",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "header",
+						"name": "Accept",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BareSuccessResponse_models.BareSuccessResponse-models.Pets"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/BareSuccessResponse_models.BareSuccessResponse-models.Pets"
+								}
+							}
+						},
+						"description": "OK"
+					},
+					"204": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/NoContent"
+								}
+							}
+						},
+						"description": "No Content"
+					},
+					"400": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							}
+						},
+						"description": "Bad Request _(validation or deserialization error)_"
+					},
+					"500": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/HTTPError"
+								}
+							}
+						},
+						"description": "Internal Server Error _(panics)_"
+					},
+					"default": {
+						"description": ""
+					}
+				},
+				"summary": "get nested wrapped",
 				"tags": [
 					"pets"
 				]

--- a/openapi.go
+++ b/openapi.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3gen"
@@ -512,17 +511,16 @@ func transformTypeName(s string) string {
 	prefix := s[:start]
 	inside := s[start+1 : end]
 
-	// Strip the package import path while preserving type modifiers like "[]" or "*".
-	// Go package paths start with a letter (e.g. "github.com/..."), while type modifiers
-	// are symbols (e.g. "[]", "*"). We keep everything before the first letter (the
-	// modifiers) and everything after the last "/" (the final "package.Type" segment).
-	if lastSlash := strings.LastIndex(inside, "/"); lastSlash != -1 {
-		pathStart := strings.IndexFunc(inside, unicode.IsLetter)
-		inside = inside[:pathStart] + inside[lastSlash+1:]
-	}
+	// Strip Go import path prefixes (e.g. "github.com/org/repo/" -> "").
+	// Import paths match: word(.word)* followed by one or more /word/ segments.
+	inside = importPathRe.ReplaceAllString(inside, "")
 
-	// Replace characters not allowed in OpenAPI 3 identifiers (valid: a-zA-Z0-9._-)
-	inside = strings.ReplaceAll(inside, "[]", "Array-")
+	// Sanitize Go type syntax into valid OpenAPI 3 identifiers (a-zA-Z0-9._-).
+	// Order matters: "[]" must be replaced before "[" so slices become "Array-" not "-".
+	inside = strings.NewReplacer("[]", "Array-", "[", "-", "]", "-", "*", "").Replace(inside)
+	inside = strings.TrimRight(inside, "-")
 
 	return prefix + "_" + inside
 }
+
+var importPathRe = regexp.MustCompile(`\w+(?:\.\w+)*/(?:\w[\w.-]*/)*`)

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -783,6 +783,36 @@ func Test_transformTypeName(t *testing.T) {
 			input:    "Response[[]github.com/org/repo/model.QuotaData]",
 			expected: "Response_Array-model.QuotaData",
 		},
+		{
+			name:     "pointer type parameter",
+			input:    "Response[*model.User]",
+			expected: "Response_model.User",
+		},
+		{
+			name:     "pointer type parameter with package path",
+			input:    "Response[*github.com/org/repo/model.User]",
+			expected: "Response_model.User",
+		},
+		{
+			name:     "map type parameter",
+			input:    "Response[map[string]model.User]",
+			expected: "Response_map-string-model.User",
+		},
+		{
+			name:     "map type parameter with package path",
+			input:    "Response[map[string]github.com/org/repo/model.User]",
+			expected: "Response_map-string-model.User",
+		},
+		{
+			name:     "nested generic",
+			input:    "Outer[Inner[model.User]]",
+			expected: "Outer_Inner-model.User",
+		},
+		{
+			name:     "nested generic with package path",
+			input:    "Outer[Inner[github.com/org/repo/model.User]]",
+			expected: "Outer_Inner-model.User",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Follow-up to #696: `transformTypeName` still produced invalid OpenAPI 3 schema names for `*T`, `map[K]V`, and nested generics
- Replace the single `[]`->`Array-` substitution with a general sanitizer handling all Go type syntax characters
- Replace the manual package path stripping with a regex that correctly handles import paths after type modifiers like `map[string]`

## Reproduction
Any controller returning a generic wrapper with pointer, map, or nested generic parameters produces an invalid schema name:

```go
func A(c ContextNoBody) (*Response[*Model], error) { ... }       // Response_*Model (invalid *)
func B(c ContextNoBody) (*Response[map[string]Model], error) { } // Response_map[string]Model (invalid [])
func C(c ContextNoBody) (*Outer[Inner[Model]], error) { ... }    // Outer_Inner[Model] (invalid [])
```

## Changes
- `openapi.go`: Replace manual path stripping + single `ReplaceAll` with regex-based import path removal + `strings.NewReplacer` that handles `[]`, `[`, `]`, `*`
- `openapi_test.go`: Add test cases for pointer, map, and nested generic type parameters (with and without package paths)
- `examples/petstore`: Add nested generic endpoint to exercise the case in the golden spec

## Example

| Input | Before (broken) | After (fixed) |
|---|---|---|
| `Response[*model.User]` | `Response_*model.User` | `Response_model.User` |
| `Response[map[string]model.User]` | `Response_map[string]model.User` | `Response_map-string-model.User` |
| `Outer[Inner[model.User]]` | `Outer_Inner[model.User]` | `Outer_Inner-model.User` |

Fixes remaining cases from #560.