### PR TITLE
fix: prevent phantom contentless default response in OpenAPI spec

### DIFF
--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -504,9 +504,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "filter pets",
@@ -630,9 +627,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "post pets",
@@ -784,9 +778,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "get all pets",
@@ -877,9 +868,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "get all pets wrapped",
@@ -981,9 +969,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "get all pets by age",
@@ -1081,9 +1066,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "get pet by name",
@@ -1184,9 +1166,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "generic request and response",
@@ -1295,9 +1274,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "Update a pet with JSON-only body",
@@ -1387,9 +1363,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "get nested wrapped",
@@ -1470,9 +1443,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "func1",
@@ -1615,9 +1585,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "filter pets strongly typed",
@@ -1715,9 +1682,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "delete pets",
@@ -1819,9 +1783,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "get pets",
@@ -1928,9 +1889,6 @@
 							}
 						},
 						"description": "Internal Server Error _(panics)_"
-					},
-					"default": {
-						"description": ""
 					}
 				},
 				"summary": "put pets",

--- a/openapi.go
+++ b/openapi.go
@@ -180,6 +180,11 @@ func RegisterOpenAPIOperation[T, B, P any](openapi *OpenAPI, route Route[T, B, P
 	if route.Operation == nil {
 		route.Operation = openapi3.NewOperation()
 	}
+	// Pre-initialize Responses to avoid kin-openapi's NewResponses() injecting
+	// a phantom contentless "default" response when AddResponse hits a nil check.
+	if route.Operation.Responses == nil {
+		route.Operation.Responses = openapi3.NewResponsesWithCapacity(4)
+	}
 
 	if route.FullName == "" {
 		route.FullName = route.Path
@@ -276,6 +281,9 @@ func RegisterOpenAPIOperation[T, B, P any](openapi *OpenAPI, route Route[T, B, P
 func (route *Route[ResponseBody, RequestBody, Params]) RegisterParams() error {
 	if route.Operation == nil {
 		route.Operation = openapi3.NewOperation()
+	}
+	if route.Operation.Responses == nil {
+		route.Operation.Responses = openapi3.NewResponsesWithCapacity(4)
 	}
 	params := *new(Params)
 	typeOfParams := reflect.TypeOf(params)

--- a/option.go
+++ b/option.go
@@ -408,7 +408,7 @@ func OptionAddError(code int, description string, errorType ...any) RouteOption 
 			WithContent(content)
 
 		if r.Operation.Responses == nil {
-			r.Operation.Responses = openapi3.NewResponses()
+			r.Operation.Responses = openapi3.NewResponsesWithCapacity(1)
 		}
 		r.Operation.Responses.Set(strconv.Itoa(code), &openapi3.ResponseRef{Value: response})
 	}
@@ -430,7 +430,7 @@ type Response struct {
 func OptionAddResponse(code int, description string, response Response) RouteOption {
 	return func(r *BaseRoute) {
 		if r.Operation.Responses == nil {
-			r.Operation.Responses = openapi3.NewResponses()
+			r.Operation.Responses = openapi3.NewResponsesWithCapacity(1)
 		}
 		r.Operation.Responses.Set(
 			strconv.Itoa(code), &openapi3.ResponseRef{
@@ -474,7 +474,7 @@ func OptionRequestBody(requestBody RequestBody) RouteOption {
 func OptionDefaultResponse(description string, response Response) RouteOption {
 	return func(r *BaseRoute) {
 		if r.Operation.Responses == nil {
-			r.Operation.Responses = openapi3.NewResponses()
+			r.Operation.Responses = openapi3.NewResponsesWithCapacity(1)
 		}
 		r.Operation.Responses.Set(
 			"default", &openapi3.ResponseRef{

--- a/option_test.go
+++ b/option_test.go
@@ -409,7 +409,7 @@ func TestAddError(t *testing.T) {
 		route := fuego.Get(s, "/test", helloWorld, fuego.OptionAddError(http.StatusConflict, "Conflict: Pet with the same name already exists"))
 
 		t.Log("route.Operation.Responses", route.Operation.Responses)
-		require.Equal(t, 5, route.Operation.Responses.Len()) // 200, 400, 409, 500, default
+		require.Equal(t, 4, route.Operation.Responses.Len()) // 200, 400, 409, 500
 		resp := route.Operation.Responses.Value("409")
 		require.NotNil(t, resp)
 		require.Equal(t, "Conflict: Pet with the same name already exists", *route.Operation.Responses.Value("409").Value.Description)
@@ -435,7 +435,7 @@ func TestAddResponse(t *testing.T) {
 				Type:         fuego.HTTPError{},
 			},
 		))
-		require.Equal(t, 5, route.Operation.Responses.Len()) // 200, 400, 409, 500, default
+		require.Equal(t, 4, route.Operation.Responses.Len()) // 200, 400, 409, 500
 		resp := route.Operation.Responses.Value("409")
 		require.NotNil(t, resp)
 		require.NotNil(t, resp.Value.Content.Get("application/json"))
@@ -452,7 +452,7 @@ func TestAddResponse(t *testing.T) {
 				Type: fuego.HTTPError{},
 			},
 		))
-		require.Equal(t, 5, route.Operation.Responses.Len()) // 200, 400, 409, 500, default
+		require.Equal(t, 4, route.Operation.Responses.Len()) // 200, 400, 409, 500
 		resp := route.Operation.Responses.Value("409")
 		require.NotNil(t, resp)
 		require.NotNil(t, resp.Value.Content.Get("application/json"))
@@ -470,7 +470,7 @@ func TestAddResponse(t *testing.T) {
 				ContentTypes: []string{"application/x-yaml"},
 			},
 		))
-		require.Equal(t, 4, route.Operation.Responses.Len()) // 200, 400, 500, default
+		require.Equal(t, 3, route.Operation.Responses.Len()) // 200, 400, 500
 		resp := route.Operation.Responses.Value("200")
 		require.NotNil(t, resp)
 		require.Nil(t, resp.Value.Content.Get("application/json"))


### PR DESCRIPTION
## Summary

Every route in the generated OpenAPI spec includes a phantom contentless `"default"` response that no one explicitly added. This causes code generation tools to emit void unions for all response types.

### The bug origin

`kin-openapi`'s `NewResponses()` with no arguments auto-inserts `"default": {"description": ""}` with no content schema. In fuego, this gets triggered through two paths:

1. **`option.go`** (lines 411, 433, 477): `OptionAddError`, `OptionAddResponse`, and `OptionDefaultResponse` call `openapi3.NewResponses()` to initialize `Operation.Responses` when nil
2. **`openapi3.Operation.AddResponse`** (inside kin-openapi): also calls `NewResponses()` when `Responses` is nil, triggered when `addResponseIfNotSet` adds the global 400/500 responses

### Reproduction

Any route produces a spec with the phantom default:

```json
{
  "responses": {
    "200": { "description": "OK", "content": { ... } },
    "400": { "description": "Bad Request", "content": { ... } },
    "500": { "description": "Internal Server Error", "content": { ... } },
    "default": { "description": "" }
  }
}
```

Code generation tools (Orval, openapi-typescript, openapi-generator) interpret the contentless default as `void`:

```typescript
// Generated (broken):
type Response = void | ActualResponseType;
// Expected:
type Response = ActualResponseType;
```

### Changes

- **`openapi.go`**: Pre-initialize `Operation.Responses` with `NewResponsesWithCapacity(4)` in both `RegisterOpenAPIOperation` functions, before any `AddResponse` calls can hit kin-openapi's nil-check phantom injection
- **`option.go`**: Replace `NewResponses()` with `NewResponsesWithCapacity(1)` in the three option functions that initialize responses
- **`option_test.go`**: Adjust response count assertions (remove the phantom default from expected counts, e.g. `5` to `4` for `// 200, 400, 409, 500`)
- **`openapi.golden.json`**: Regenerated, 42 lines removed (7 phantom `"default"` response blocks)

### Before

```
route.Operation.Responses.Len() == 5  // 200, 400, 409, 500, default
```

### After

```
route.Operation.Responses.Len() == 4  // 200, 400, 409, 500
```

### Related

Root cause fix submitted to kin-openapi: [getkin/kin-openapi#1148](https://github.com/getkin/kin-openapi/pull/1148). This PR works independently as a workaround by ensuring `Responses` is never nil when responses are added.