### PR TITLE
fix: set schema props that are of map/slice to nullable

### DIFF
--- a/examples/petstore/lib/testdata/doc/openapi.golden.json
+++ b/examples/petstore/lib/testdata/doc/openapi.golden.json
@@ -11,6 +11,7 @@
 						"items": {
 							"$ref": "#/components/schemas/Pets"
 						},
+						"nullable": true,
 						"type": "array"
 					},
 					"statusCode": {
@@ -87,6 +88,7 @@
 							"description": "Additional information about the error"
 						},
 						"description": "Additional information about the error",
+						"nullable": true,
 						"type": "object"
 					},
 					"name": {
@@ -131,6 +133,7 @@
 						"items": {
 							"$ref": "#/components/schemas/ErrorItem"
 						},
+						"nullable": true,
 						"type": "array"
 					},
 					"instance": {
@@ -193,6 +196,7 @@
 						"items": {
 							"$ref": "#/components/schemas/Treat"
 						},
+						"nullable": true,
 						"type": "array"
 					}
 				},
@@ -279,6 +283,7 @@
 						"items": {
 							"$ref": "#/components/schemas/Treat"
 						},
+						"nullable": true,
 						"type": "array"
 					}
 				},

--- a/schema_customizer.go
+++ b/schema_customizer.go
@@ -59,12 +59,13 @@ func parseValidate(tag reflect.StructTag, schema *openapi3.Schema) {
 	}
 }
 
-// determineRequired takes a reflect.Type and a schema,
-// and determines which fields should be marked as required.
-// It checks for fields that either:
-// - Don't have the `omitempty` JSON tag
-// - Have the `required` validation tag
-func determineRequired(t reflect.Type, schema *openapi3.Schema) {
+// determineFieldConstraints takes a reflect.Type and a schema,
+// and determines which fields should be marked as required and nullable.
+// It checks for fields that:
+// - Don't have the `omitempty` JSON tag marking it as required
+// - Are slices, maps, or pointers setting nullable to true
+// - Have the `required` validation tag setting nullable to true and required
+func determineFieldConstraints(t reflect.Type, schema *openapi3.Schema) {
 	if t.Kind() != reflect.Struct {
 		return
 	}
@@ -78,7 +79,7 @@ func determineRequired(t reflect.Type, schema *openapi3.Schema) {
 				ft = ft.Elem()
 			}
 			if ft.Kind() == reflect.Struct {
-				determineRequired(ft, schema)
+				determineFieldConstraints(ft, schema)
 				continue
 			}
 		}
@@ -99,11 +100,26 @@ func determineRequired(t reflect.Type, schema *openapi3.Schema) {
 			continue
 		}
 
-		if !strings.Contains(jsonTag, ",omitempty") || slices.Contains(strings.Split(f.Tag.Get("validate"), ","), "required") {
+		hasRequired := slices.Contains(strings.Split(f.Tag.Get("validate"), ","), "required")
+		if !strings.Contains(jsonTag, ",omitempty") || hasRequired {
 			schema.Required = append(schema.Required, name)
+		}
+
+		prop, ok := schema.Properties[name]
+		if !ok {
+			// skip if properties is nil or
+			// no property for field. Common in xml parsing
+			continue
+		}
+		if isReferenceType(f.Type.Kind()) && !hasRequired {
+			prop.Value.Nullable = true
 		}
 	}
 	sort.Strings(schema.Required)
+}
+
+func isReferenceType(t reflect.Kind) bool {
+	return t == reflect.Slice || t == reflect.Map
 }
 
 // parseExample parses the "example" tag and sets the schema example.
@@ -169,7 +185,7 @@ func SchemaCustomizer(name string, t reflect.Type, tag reflect.StructTag, schema
 	parseDescription(tag, schema)
 
 	// After we are done parsing tags, get the required tags
-	determineRequired(t, schema)
+	determineFieldConstraints(t, schema)
 
 	return nil
 }

--- a/schema_customizer_test.go
+++ b/schema_customizer_test.go
@@ -1,0 +1,135 @@
+package fuego
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetermineFieldConstraints(t *testing.T) {
+	t.Run("non-struct type is a no-op", func(t *testing.T) {
+		schema := &openapi3.Schema{}
+		determineFieldConstraints(reflect.TypeFor[string](), schema)
+		assert.Empty(t, schema.Required)
+	})
+	t.Run("private field is skipped", func(t *testing.T) {
+		type S struct {
+			private string //nolint:unused
+		}
+		schema := &openapi3.Schema{
+			Properties: openapi3.Schemas{},
+		}
+		determineFieldConstraints(reflect.TypeFor[S](), schema)
+		assert.Empty(t, schema.Required)
+	})
+	t.Run("json tag - is skipped", func(t *testing.T) {
+		type S struct {
+			Hidden string `json:"-"`
+		}
+		schema := &openapi3.Schema{
+			Properties: openapi3.Schemas{},
+		}
+		determineFieldConstraints(reflect.TypeFor[S](), schema)
+		assert.Empty(t, schema.Required)
+	})
+
+	t.Run("field without omitempty is required", func(t *testing.T) {
+		type S struct {
+			Name string `json:"name"`
+		}
+		schema := &openapi3.Schema{
+			Properties: openapi3.Schemas{
+				"name": &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		determineFieldConstraints(reflect.TypeFor[S](), schema)
+		assert.Contains(t, schema.Required, "name")
+	})
+
+	t.Run("field with omitempty is not required", func(t *testing.T) {
+		type S struct {
+			Name string `json:"name,omitempty"`
+		}
+		schema := &openapi3.Schema{
+			Properties: openapi3.Schemas{
+				"name": &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		determineFieldConstraints(reflect.TypeFor[S](), schema)
+		assert.NotContains(t, schema.Required, "name")
+	})
+
+	t.Run("field with validate:\"required\" is required", func(t *testing.T) {
+		type S struct {
+			Name string `json:"name,omitempty" validate:"required"`
+		}
+		schema := &openapi3.Schema{
+			Properties: openapi3.Schemas{
+				"name": &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		determineFieldConstraints(reflect.TypeFor[S](), schema)
+		assert.Contains(t, schema.Required, "name")
+		assert.False(t, schema.Properties["name"].Value.Nullable)
+	})
+
+	t.Run("slice field is nullable", func(t *testing.T) {
+		type S struct {
+			Items []string `json:"items"`
+		}
+		schema := &openapi3.Schema{
+			Properties: openapi3.Schemas{
+				"items": &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		determineFieldConstraints(reflect.TypeFor[S](), schema)
+		assert.True(t, schema.Properties["items"].Value.Nullable)
+	})
+
+	t.Run("map field is nullable", func(t *testing.T) {
+		type S struct {
+			Meta map[string]string `json:"meta"`
+		}
+		schema := &openapi3.Schema{
+			Properties: openapi3.Schemas{
+				"meta": &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		determineFieldConstraints(reflect.TypeFor[S](), schema)
+		assert.True(t, schema.Properties["meta"].Value.Nullable)
+	})
+
+	t.Run("string field is not nullable", func(t *testing.T) {
+		type S struct {
+			Name string `json:"name"`
+		}
+		schema := &openapi3.Schema{
+			Properties: openapi3.Schemas{
+				"name": &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		determineFieldConstraints(reflect.TypeFor[S](), schema)
+		assert.False(t, schema.Properties["name"].Value.Nullable)
+	})
+
+	t.Run("required fields are sorted", func(t *testing.T) {
+		type S struct {
+			Zebra string `json:"zebra"`
+			Apple string `json:"apple"`
+			Mango string `json:"mango"`
+		}
+		schema := &openapi3.Schema{
+			Properties: openapi3.Schemas{
+				"zebra": &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+				"apple": &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+				"mango": &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		determineFieldConstraints(reflect.TypeFor[S](), schema)
+		require.Len(t, schema.Required, 3)
+		assert.Equal(t, []string{"apple", "mango", "zebra"}, schema.Required)
+	})
+}


### PR DESCRIPTION
Found this issue at my day job. It's primarily surfacing cause we switch omitEmpty to set the required field rather than nullable. However, this bug was present before.

Essentially this sets maps/slice go types to be nullable true by default. Since most of of the literature from the go wiki prefers nil https://go.dev/wiki/CodeReviewComments#declaring-empty-slices. 

> They are functionally equivalent—their len and cap are both zero—but the nil slice is the preferred style.

between that and us literally having no control over what the user is doing in their implementation. I believe this is a sane default. The user can always use required if they never want the slice to be `null`