### PR TITLE
feat: parse validate:"oneof=..." into OpenAPI enum

### DIFF
--- a/schema_customizer.go
+++ b/schema_customizer.go
@@ -20,6 +20,7 @@ import (
 //   - min=1 => minLength=1 (for strings)
 //   - max=100 => max=100 (for integers)
 //   - max=100 => maxLength=100 (for strings)
+//   - oneof=a b c => enum=[a,b,c] (matches go-playground/validator)
 func parseValidate(tag reflect.StructTag, schema *openapi3.Schema) {
 	validateTag, ok := tag.Lookup("validate")
 	if !ok {
@@ -54,6 +55,33 @@ func parseValidate(tag reflect.StructTag, schema *openapi3.Schema) {
 				//nolint:gosec // disable G115
 				maxPtr := uint64(maxValue)
 				schema.MaxLength = &maxPtr
+			}
+		}
+		if rest, ok := strings.CutPrefix(validateTag, "oneof="); ok {
+			values := strings.Fields(rest)
+			if len(values) == 0 {
+				continue
+			}
+			schema.Enum = make([]any, 0, len(values))
+			for _, v := range values {
+				switch {
+				case schema.Type.Is(openapi3.TypeInteger):
+					n, err := strconv.Atoi(v)
+					if err != nil {
+						slog.Warn("oneof value might be incorrect (should be integer)", "value", v, "error", err)
+						continue
+					}
+					schema.Enum = append(schema.Enum, n)
+				case schema.Type.Is(openapi3.TypeNumber):
+					n, err := strconv.ParseFloat(v, 64)
+					if err != nil {
+						slog.Warn("oneof value might be incorrect (should be number)", "value", v, "error", err)
+						continue
+					}
+					schema.Enum = append(schema.Enum, n)
+				default:
+					schema.Enum = append(schema.Enum, v)
+				}
 			}
 		}
 	}

--- a/schema_customizer_test.go
+++ b/schema_customizer_test.go
@@ -133,3 +133,35 @@ func TestDetermineFieldConstraints(t *testing.T) {
 		assert.Equal(t, []string{"apple", "mango", "zebra"}, schema.Required)
 	})
 }
+
+func TestParseValidateOneof(t *testing.T) {
+	t.Run("string oneof adds enum values", func(t *testing.T) {
+		schema := &openapi3.Schema{Type: &openapi3.Types{openapi3.TypeString}}
+		parseValidate(reflect.StructTag(`validate:"oneof=a b c"`), schema)
+		assert.Equal(t, []any{"a", "b", "c"}, schema.Enum)
+	})
+
+	t.Run("integer oneof adds typed enum values", func(t *testing.T) {
+		schema := &openapi3.Schema{Type: &openapi3.Types{openapi3.TypeInteger}}
+		parseValidate(reflect.StructTag(`validate:"oneof=1 2 3"`), schema)
+		assert.Equal(t, []any{1, 2, 3}, schema.Enum)
+	})
+
+	t.Run("number oneof adds typed enum values", func(t *testing.T) {
+		schema := &openapi3.Schema{Type: &openapi3.Types{openapi3.TypeNumber}}
+		parseValidate(reflect.StructTag(`validate:"oneof=1.5 2.5"`), schema)
+		assert.Equal(t, []any{1.5, 2.5}, schema.Enum)
+	})
+
+	t.Run("oneof works alongside required", func(t *testing.T) {
+		schema := &openapi3.Schema{Type: &openapi3.Types{openapi3.TypeString}}
+		parseValidate(reflect.StructTag(`validate:"required,oneof=foo bar"`), schema)
+		assert.Equal(t, []any{"foo", "bar"}, schema.Enum)
+	})
+
+	t.Run("no oneof leaves enum nil", func(t *testing.T) {
+		schema := &openapi3.Schema{Type: &openapi3.Types{openapi3.TypeString}}
+		parseValidate(reflect.StructTag(`validate:"required"`), schema)
+		assert.Nil(t, schema.Enum)
+	})
+}


### PR DESCRIPTION
## Summary

`parseValidate` handles `min=`, `max=`, and `required`, but ignores `oneof`. Runtime validation already enforces it via `go-playground/validator`, so the spec is weaker than the actual contract: codegen tools (Orval, openapi-generator) emit `string` instead of a typed union.

This PR populates `schema.Enum` from `oneof=...`, with values typed for `string`, `integer`, and `number` schemas. Same convention as `min=` / `max=` (validate-tag-based, no new tag).

Addresses part of #707 for body / query-struct fields. #735 covers the `option.Query(..., param.Enum(...))` path.

### Changes

- **schema_customizer.go**: parse `oneof=...` in `parseValidate`. Whitespace-split per `go-playground/validator`'s spec, values typed by schema kind
- **schema_customizer_test.go**: `TestParseValidateOneof` covering string, integer, number, `required,oneof` combo, and no-`oneof` no-op

### Before / After

```go
Bucket string `query:"bucket" validate:"oneof=1m 5m 15m 1h 1d"`
```

| | Before | After |
| --- | --- | --- |
| OpenAPI | `type: string` | `type: string` + `enum: [1m, 5m, 15m, 1h, 1d]` |
| Orval client | `bucket?: string` | `bucket?: '1m' \| '5m' \| '15m' \| '1h' \| '1d'` |

### Notes

- Bad numeric values are skipped with `slog.Warn`, matching existing `min=` / `max=` handling
- No new exported API, no breaking changes