### PR TITLE
feat: add MiddlewareConfig.DisableControllerSection

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -113,6 +113,7 @@ func WithResponseContentType(consumes ...string) func(*Engine) {
 }
 
 type MiddlewareConfig struct {
+	DisableControllerSection bool
 	DisableMiddlewareSection bool
 	MaxNumberOfMiddlewares   int
 	ShortMiddlewaresPaths    bool
@@ -120,6 +121,7 @@ type MiddlewareConfig struct {
 
 func WithMiddlewareConfig(cfg MiddlewareConfig) EngineOption {
 	return func(e *Engine) {
+		e.OpenAPI.Config.MiddlewareConfig.DisableControllerSection = cfg.DisableControllerSection
 		e.OpenAPI.Config.MiddlewareConfig.DisableMiddlewareSection = cfg.DisableMiddlewareSection
 		e.OpenAPI.Config.MiddlewareConfig.ShortMiddlewaresPaths = cfg.ShortMiddlewaresPaths
 		if cfg.MaxNumberOfMiddlewares != 0 {

--- a/net_http_mux.go
+++ b/net_http_mux.go
@@ -206,16 +206,30 @@ func camelToHuman(s string) string {
 
 // DefaultDescription returns a default .md description for a controller
 func DefaultDescription[T any](handler string, middlewares []T, middlewareConfig *MiddlewareConfig) string {
-	// Start with the controller info
-	description := "#### Controller: \n\n`" + handler + "`"
+	middlewaresDisabled := middlewareConfig.DisableMiddlewareSection || len(middlewares) == 0
+
+	// If both sections are disabled, emit nothing so the route's own
+	// description flows through without a leading separator.
+	if middlewareConfig.DisableControllerSection && middlewaresDisabled {
+		return ""
+	}
+
+	// Start with the controller info (unless disabled)
+	var description string
+	if !middlewareConfig.DisableControllerSection {
+		description = "#### Controller: \n\n`" + handler + "`"
+	}
 
 	// If middlewares are disabled, or there aren't any, skip the block entirely
-	if middlewareConfig.DisableMiddlewareSection || len(middlewares) == 0 {
+	if middlewaresDisabled {
 		return description + "\n\n---\n\n"
 	}
 
 	// Add the middlewares section
-	description += "\n\n#### Middlewares:\n"
+	if description != "" {
+		description += "\n\n"
+	}
+	description += "#### Middlewares:\n"
 
 	for i, fn := range middlewares {
 		// If we've reached the maximum configured to display, show a summary and stop

--- a/option_test.go
+++ b/option_test.go
@@ -1040,6 +1040,57 @@ func TestOptionDescription(t *testing.T) {
 
 		require.Equal(t, "#### Controller: \n\n`github.com/go-fuego/fuego_test.helloWorld`\n\n#### Middlewares:\n\n- `fuego.defaultLogger.middleware`\n- `fuego_test.dummyMiddleware`\n- `fuego_test.dummyMiddleware`\n- more middleware…\n\n---\n\ntest description", route.Operation.Description)
 	})
+	t.Run("Disable controller section", func(t *testing.T) {
+		s := fuego.NewServer(
+			fuego.WithEngineOptions(
+				fuego.WithMiddlewareConfig(
+					fuego.MiddlewareConfig{
+						DisableControllerSection: true,
+					},
+				),
+			),
+		)
+
+		route := fuego.Get(s, "/test", helloWorld,
+			option.Description("test description"),
+		)
+
+		require.Equal(t, "#### Middlewares:\n\n- `github.com/go-fuego/fuego.defaultLogger.middleware`\n\n---\n\ntest description", route.Operation.Description)
+	})
+	t.Run("Disable controller and middleware sections", func(t *testing.T) {
+		s := fuego.NewServer(
+			fuego.WithEngineOptions(
+				fuego.WithMiddlewareConfig(
+					fuego.MiddlewareConfig{
+						DisableControllerSection: true,
+						DisableMiddlewareSection: true,
+					},
+				),
+			),
+		)
+
+		route := fuego.Get(s, "/test", helloWorld,
+			option.Description("test description"),
+		)
+
+		require.Equal(t, "test description", route.Operation.Description)
+	})
+	t.Run("Disable controller and middleware sections, no description", func(t *testing.T) {
+		s := fuego.NewServer(
+			fuego.WithEngineOptions(
+				fuego.WithMiddlewareConfig(
+					fuego.MiddlewareConfig{
+						DisableControllerSection: true,
+						DisableMiddlewareSection: true,
+					},
+				),
+			),
+		)
+
+		route := fuego.Get(s, "/test", helloWorld)
+
+		require.Empty(t, route.Operation.Description)
+	})
 }
 
 func TestDefaultStatusCode(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a `DisableControllerSection` knob to `MiddlewareConfig`, mirroring the existing `DisableMiddlewareSection`. Lets users opt out of the auto-injected `#### Controller:` block in operation descriptions, which exposes Go package paths in the public OpenAPI spec.

When both sections are disabled, `DefaultDescription` returns an empty string so the route's own description flows through without a leading `---` separator.

### Changes

- **engine.go**: add `DisableControllerSection bool` to `MiddlewareConfig`, wire it through `WithMiddlewareConfig`
- **net_http_mux.go**: skip the `#### Controller:` line when disabled; return `""` when both sections are off
- **option_test.go**: 3 new subtests in `TestOptionDescription`: controller-only disabled, both disabled with description, both disabled without description