### PR TITLE
Fix nil-pointer panic in `Send*` serializers on write failure

### DIFF
--- a/serialization.go
+++ b/serialization.go
@@ -79,6 +79,13 @@ func transformOut[T any](ctx context.Context, ans T) (T, error) {
 	return ans, nil
 }
 
+func requestContext(r *http.Request) context.Context {
+	if r == nil {
+		return context.Background()
+	}
+	return r.Context()
+}
+
 type Sender func(http.ResponseWriter, *http.Request, any) error
 
 // Send sends a response.
@@ -135,7 +142,7 @@ var SendYAML = func(w http.ResponseWriter, r *http.Request, ans any) (err error)
 	err = yaml.NewEncoder(w).Encode(ans)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		slog.ErrorContext(r.Context(), "Cannot serialize returned response to YAML", "error", err)
+		slog.ErrorContext(requestContext(r), "Cannot serialize returned response to YAML", "error", err)
 		_, _ = w.Write([]byte(`{"error":"Cannot serialize returned response to YAML"}`))
 	}
 	return err
@@ -161,7 +168,7 @@ var SendJSON = func(w http.ResponseWriter, r *http.Request, ans any) error {
 	w.Header().Set("Content-Type", "application/json")
 	err := json.NewEncoder(w).Encode(ans)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "Cannot serialize returned response to JSON", "error", err, "errtype", fmt.Sprintf("%T", err))
+		slog.ErrorContext(requestContext(r), "Cannot serialize returned response to JSON", "error", err, "errtype", fmt.Sprintf("%T", err))
 		var unsupportedType *json.UnsupportedTypeError
 		if errors.As(err, &unsupportedType) {
 			return NotAcceptableError{
@@ -225,7 +232,7 @@ var SendXML = func(w http.ResponseWriter, r *http.Request, ans any) error {
 	w.Header().Set("Content-Type", "application/xml")
 	err := xml.NewEncoder(w).Encode(ans)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "Cannot serialize returned response to XML", "error", err, "errtype", fmt.Sprintf("%T", err))
+		slog.ErrorContext(requestContext(r), "Cannot serialize returned response to XML", "error", err, "errtype", fmt.Sprintf("%T", err))
 		var unsupportedType *xml.UnsupportedTypeError
 		if errors.As(err, &unsupportedType) {
 			return NotAcceptableError{
@@ -250,7 +257,7 @@ func SendXMLError(w http.ResponseWriter, r *http.Request, err error) {
 	w.WriteHeader(status)
 	err = SendXML(w, r, err)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "Cannot serialize returned response to XML", "error", err)
+		slog.ErrorContext(requestContext(r), "Cannot serialize returned response to XML", "error", err)
 		_, _ = w.Write([]byte(`{"error":"Cannot serialize returned response to XML"}`))
 	}
 }
@@ -262,7 +269,7 @@ var SendHTML = func(w http.ResponseWriter, r *http.Request, ans any) error {
 
 	ctxRenderer, ok := ans.(CtxRenderer)
 	if ok {
-		return ctxRenderer.Render(r.Context(), w)
+		return ctxRenderer.Render(requestContext(r), w)
 	}
 
 	renderer, ok := ans.(Renderer)

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -667,3 +667,25 @@ func TestSendError(t *testing.T) {
 		})
 	}
 }
+
+func TestSend_NilRequest_WriteError_NoPanic(t *testing.T) {
+	cases := map[string]func(http.ResponseWriter, *http.Request, any) error{
+		"json": SendJSON,
+		"xml":  SendXML,
+		"yaml": SendYAML,
+	}
+	for name, send := range cases {
+		t.Run(name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				err := send(&errorWriter{}, nil, response{Message: "Hello World", Code: http.StatusOK})
+				require.Error(t, err, "expected the underlying write error to be returned")
+			})
+		})
+	}
+
+	t.Run("html CtxRenderer", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			_ = SendHTML(httptest.NewRecorder(), nil, RenderString("Hello World"))
+		})
+	})
+}


### PR DESCRIPTION
## Summary

Closes #795

The `Send*` serializers deref `r.Context()` in their error branches without a nil
check. If the response **write** fails and the serializer was called with a nil
request, it panics instead of just logging the write error.

This happens for ordinary reasons: the client disconnects mid-response, or
`WriteTimeout` fires. The return value serializes fine (the encoder error is a write
error), so fuego falls into its error-serialization path, which can call the
serializers with a nil request. The `Send*` vars are also exported and overridable, so
direct callers can pass `nil` too.

## Fix

Added a tiny `requestContext(r)` helper that returns `context.Background()` when `r`
is nil, and used it at every `r.Context()` deref in `SendYAML`, `SendJSON`, `SendXML`,
`SendXMLError`, and `SendHTML`.

No API or behavior change when `r != nil`; when it's nil we log against
`context.Background()` instead of panicking.

## Tests

Added `TestSend_NilRequest_WriteError_NoPanic`: drives JSON/XML/YAML through a failing
writer with a nil request (asserts no panic, write error returned), plus an HTML
`CtxRenderer` case. It panics before the fix, passes after; rest of the suite stays green.
