### PR TITLE
Propose to change schema name generation

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -92,10 +92,10 @@ func TestWithRequestContentType(t *testing.T) {
 
 		content := route.Operation.RequestBody.Value.Content
 		require.NotNil(t, content["application/json"])
-		assert.Equal(t, "#/components/schemas/ReqBody", content["application/json"].Schema.Ref)
+		assert.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_ReqBody", content["application/json"].Schema.Ref)
 
 		require.NotNil(t, content["application/xml"])
-		assert.Equal(t, "#/components/schemas/ReqBody", content["application/xml"].Schema.Ref)
+		assert.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_ReqBody", content["application/xml"].Schema.Ref)
 
 		require.Nil(t, content["application/x-yaml"])
 
@@ -125,7 +125,7 @@ func TestWithResponseContentType(t *testing.T) {
 		require.NotNil(t, response)
 		content := response.Value.Content
 		require.Contains(t, content, "application/yml")
-		assert.Equal(t, "#/components/schemas/Resp", content["application/yml"].Schema.Ref)
+		assert.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_Resp", content["application/yml"].Schema.Ref)
 
 		require.NotContains(t, content, "application/xml")
 

--- a/generics_test.go
+++ b/generics_test.go
@@ -49,8 +49,8 @@ func TestGenericReturnType(t *testing.T) {
 	require.Equal(t, &openapi3.Types{"object"}, requestType.Type)
 	require.Equal(t, &openapi3.Types{"string"}, requestType.Properties["thing"].Value.Type)
 	// "data" is a User struct, now a $ref to a component schema
-	require.Equal(t, "#/components/schemas/User", requestType.Properties["data"].Ref)
-	userSchema := s.OpenAPI.Description().Components.Schemas["User"].Value
+	require.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_test_User", requestType.Properties["data"].Ref)
+	userSchema := s.OpenAPI.Description().Components.Schemas["github.com_go-fuego_fuego_test_User"].Value
 	require.Equal(t, &openapi3.Types{"object"}, userSchema.Type)
 	require.Equal(t, &openapi3.Types{"integer"}, userSchema.Properties["id"].Value.Type)
 
@@ -59,7 +59,7 @@ func TestGenericReturnType(t *testing.T) {
 	require.Equal(t, &openapi3.Types{"integer"}, responseType.Properties["statusCode"].Value.Type)
 
 	// "result" is a User struct, now a $ref to a component schema
-	require.Equal(t, "#/components/schemas/User", responseType.Properties["result"].Ref)
+	require.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_test_User", responseType.Properties["result"].Ref)
 	require.Equal(t, &openapi3.Types{"object"}, userSchema.Type)
 	require.Equal(t, &openapi3.Types{"integer"}, userSchema.Properties["id"].Value.Type)
 	require.Equal(t, &openapi3.Types{"string"}, userSchema.Properties["name"].Value.Type)

--- a/net_http_mux.go
+++ b/net_http_mux.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 )
 
@@ -162,8 +163,8 @@ func registerStdController(s *Server, method, path string, controller func(http.
 }
 
 func withMiddlewares(controller http.Handler, middlewares ...func(http.Handler) http.Handler) http.Handler {
-	for i := len(middlewares) - 1; i >= 0; i-- {
-		controller = middlewares[i](controller)
+	for _, v := range slices.Backward(middlewares) {
+		controller = v(controller)
 	}
 	return controller
 }

--- a/openapi.go
+++ b/openapi.go
@@ -290,8 +290,8 @@ func (route *Route[ResponseBody, RequestBody, Params]) RegisterParams() error {
 	}
 
 	if typeOfParams.Kind() == reflect.Struct {
-		for i := range typeOfParams.NumField() {
-			field := typeOfParams.Field(i)
+		for field := range typeOfParams.Fields() {
+			field := field
 			var params []ParamOption
 			example, _ := field.Tag.Lookup("example")
 			if example != "" {
@@ -465,7 +465,7 @@ func dive(openapi *OpenAPI, t reflect.Type, tag SchemaTag, maxDepth int) SchemaT
 	}
 
 	switch t.Kind() {
-	case reflect.Ptr, reflect.Map, reflect.Chan, reflect.Func, reflect.UnsafePointer:
+	case reflect.Pointer, reflect.Map, reflect.Chan, reflect.Func, reflect.UnsafePointer:
 		return dive(openapi, t.Elem(), tag, maxDepth-1)
 
 	case reflect.Slice, reflect.Array:

--- a/openapi.go
+++ b/openapi.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"path"
 	"reflect"
 	"regexp"
 	"slices"
@@ -23,6 +24,7 @@ func NewOpenAPI() *OpenAPI {
 			openapi3gen.CreateComponentSchemas(openapi3gen.ExportComponentSchemasOptions{
 				ExportComponentSchemas: true,
 			}),
+			openapi3gen.CreateTypeNameGenerator(OpenAPITypeNameGenerator),
 		),
 		globalOpenAPIResponses: []openAPIResponse{},
 		Config:                 defaultOpenAPIConfig,
@@ -62,6 +64,7 @@ func (openAPI *OpenAPI) SetGeneratorSchemaCustomizer(sc openapi3gen.SchemaCustom
 		openapi3gen.CreateComponentSchemas(openapi3gen.ExportComponentSchemasOptions{
 			ExportComponentSchemas: true,
 		}),
+		openapi3gen.CreateTypeNameGenerator(OpenAPITypeNameGenerator),
 	)...)
 }
 
@@ -473,8 +476,8 @@ func dive(openapi *OpenAPI, t reflect.Type, tag SchemaTag, maxDepth int) SchemaT
 		return tag
 
 	default:
-		tag.Name = transformTypeName(t.Name())
-		if t.Kind() == reflect.Struct && strings.HasPrefix(tag.Name, "DataOrTemplate") {
+		tag.Name = OpenAPITypeNameGenerator(t)
+		if t.Kind() == reflect.Struct && strings.HasPrefix(t.Name(), "DataOrTemplate[") {
 			return dive(openapi, t.Field(0).Type, tag, maxDepth-1)
 		}
 		tag.Ref = "#/components/schemas/" + tag.Name
@@ -501,6 +504,9 @@ func (openAPI *OpenAPI) createSchema(key string, v any) *openapi3.SchemaRef {
 	if err != nil {
 		slog.Error("Error generating schema", "key", key, "error", err)
 	}
+	if schemaRef.Value == nil {
+		panic("SchemaRef Value should not be nil, openapi schema key mismatch for " + key)
+	}
 	schemaRef.Value.Description = key + " schema"
 
 	descriptionable, ok := v.(OpenAPIDescriptioner)
@@ -524,12 +530,13 @@ type OpenAPIDescriptioner interface {
 func (openAPI *OpenAPI) resolveSchemaRefs() {
 	schemas := openAPI.Description().Components.Schemas
 	prefix := "#/components/schemas/"
+	visited := make(map[*openapi3.Schema]bool)
 
 	for _, schemaRef := range schemas {
 		if schemaRef == nil || schemaRef.Value == nil {
 			continue
 		}
-		resolveRefsInSchema(schemaRef.Value, schemas, prefix)
+		resolveRefsInSchema(schemaRef.Value, schemas, prefix, visited)
 	}
 
 	// Also resolve refs in path operation schemas (request/response bodies)
@@ -540,7 +547,7 @@ func (openAPI *OpenAPI) resolveSchemaRefs() {
 				if op.RequestBody != nil && op.RequestBody.Value != nil {
 					for _, t := range op.RequestBody.Value.Content {
 						if t.Schema != nil {
-							resolveRef(t.Schema, schemas, prefix)
+							resolveRef(t.Schema, schemas, prefix, visited)
 						}
 					}
 				}
@@ -552,7 +559,7 @@ func (openAPI *OpenAPI) resolveSchemaRefs() {
 					}
 					for _, t := range resp.Value.Content {
 						if t.Schema != nil {
-							resolveRef(t.Schema, schemas, prefix)
+							resolveRef(t.Schema, schemas, prefix, visited)
 						}
 					}
 				}
@@ -561,20 +568,25 @@ func (openAPI *OpenAPI) resolveSchemaRefs() {
 	}
 }
 
-func resolveRefsInSchema(schema *openapi3.Schema, schemas openapi3.Schemas, prefix string) {
+func resolveRefsInSchema(schema *openapi3.Schema, schemas openapi3.Schemas, prefix string, visited map[*openapi3.Schema]bool) {
+	if visited[schema] {
+		return
+	}
+	visited[schema] = true
+
 	for _, propRef := range schema.Properties {
-		resolveRef(propRef, schemas, prefix)
+		resolveRef(propRef, schemas, prefix, visited)
 	}
 
 	if schema.Items != nil {
-		resolveRef(schema.Items, schemas, prefix)
+		resolveRef(schema.Items, schemas, prefix, visited)
 	}
 	if schema.AdditionalProperties.Schema != nil {
-		resolveRef(schema.AdditionalProperties.Schema, schemas, prefix)
+		resolveRef(schema.AdditionalProperties.Schema, schemas, prefix, visited)
 	}
 }
 
-func resolveRef(ref *openapi3.SchemaRef, schemas openapi3.Schemas, prefix string) {
+func resolveRef(ref *openapi3.SchemaRef, schemas openapi3.Schemas, prefix string, visited map[*openapi3.Schema]bool) {
 	if ref == nil {
 		return
 	}
@@ -594,37 +606,25 @@ func resolveRef(ref *openapi3.SchemaRef, schemas openapi3.Schemas, prefix string
 		}
 	}
 	if ref.Value != nil {
-		resolveRefsInSchema(ref.Value, schemas, prefix)
+		resolveRefsInSchema(ref.Value, schemas, prefix, visited)
 	}
 }
 
-// Transform the type name to a more readable & valid OpenAPI 3 format.
-// Useful for generics.
-// Example: "BareSuccessResponse[github.com/go-fuego/fuego/examples/petstore/models.Pets]" -> "BareSuccessResponse_models.Pets"
-// Example: "BareSuccessResponse[[]github.com/go-fuego/fuego/examples/petstore/models.Pets]" -> "BareSuccessResponse_Array-models.Pets"
-func transformTypeName(s string) string {
-	start := strings.Index(s, "[")
-	if start == -1 {
-		return s
-	}
-	end := strings.LastIndex(s, "]")
-	if end == -1 {
-		return s
-	}
-
-	prefix := s[:start]
-	inside := s[start+1 : end]
-
-	// Strip Go import path prefixes (e.g. "github.com/org/repo/" -> "").
-	// Import paths match: word(.word)* followed by one or more /word/ segments.
-	inside = importPathRe.ReplaceAllString(inside, "")
+// OpenAPITypeNameGenerator implements openapi3gen.TypeNameGenerator
+// It outputs an unique schema ID from a combination of package name and type name
+func OpenAPITypeNameGenerator(t reflect.Type) string {
+	schemaName := path.Join(t.PkgPath(), t.Name())
 
 	// Sanitize Go type syntax into valid OpenAPI 3 identifiers (a-zA-Z0-9._-).
 	// Order matters: "[]" must be replaced before "[" so slices become "Array-" not "-".
-	inside = strings.NewReplacer("[]", "Array-", "[", "-", "]", "-", "*", "").Replace(inside)
-	inside = strings.TrimRight(inside, "-")
+	schemaName = strings.NewReplacer(
+		"[]", "Array-",
+		"[", "-",
+		"]", "-",
+		"*", "",
+		"/", "_",
+	).Replace(schemaName)
+	schemaName = strings.TrimRight(schemaName, "-")
 
-	return prefix + "_" + inside
+	return schemaName
 }
-
-var importPathRe = regexp.MustCompile(`\w+(?:\.\w+)*/(?:\w[\w.-]*/)*`)

--- a/openapi_operations_test.go
+++ b/openapi_operations_test.go
@@ -155,17 +155,17 @@ func TestWithGlobalResponseType(t *testing.T) {
 		t.Run("routeGlobal", func(t *testing.T) {
 			routeGlobal := Get(s, "/test-global", testController)
 			require.Equal(t,
-				"#/components/schemas/ans",
+				"#/components/schemas/github.com_go-fuego_fuego_ans",
 				routeGlobal.Operation.Responses.Value("200").Value.Content.Get("application/json").Schema.Ref,
 			)
 			require.Equal(t,
-				"#/components/schemas/ans",
+				"#/components/schemas/github.com_go-fuego_fuego_ans",
 				routeGlobal.Operation.Responses.Value("200").Value.Content.Get("application/xml").Schema.Ref,
 			)
 			require.Equal(t, "A Global Response", *routeGlobal.Operation.Responses.Value("201").Value.Description)
 			require.Equal(t, "My 202 response with content", *routeGlobal.Operation.Responses.Value("202").Value.Description)
 			require.Equal(t,
-				"#/components/schemas/MyGlobalResponse",
+				"#/components/schemas/github.com_go-fuego_fuego_MyGlobalResponse",
 				routeGlobal.Operation.Responses.Value("202").Value.Content.Get("application/x-yaml").Schema.Ref,
 			)
 		})
@@ -176,17 +176,17 @@ func TestWithGlobalResponseType(t *testing.T) {
 				OptionAddResponse(http.StatusNoContent, "My No Content", Response{Type: struct{}{}}),
 			)
 			require.Equal(t,
-				"#/components/schemas/MyLocalResponse",
+				"#/components/schemas/github.com_go-fuego_fuego_MyLocalResponse",
 				routeCustom.Operation.Responses.Value("200").Value.Content.Get("application/json").Schema.Ref,
 			)
 			require.Equal(t,
-				"#/components/schemas/MyLocalResponse",
+				"#/components/schemas/github.com_go-fuego_fuego_MyLocalResponse",
 				routeCustom.Operation.Responses.Value("200").Value.Content.Get("application/xml").Schema.Ref,
 			)
 			require.Equal(t, "My No Content", *routeCustom.Operation.Responses.Value("204").Value.Description)
 			require.Equal(t, "My 202 response with content", *routeCustom.Operation.Responses.Value("202").Value.Description)
 			require.Equal(t,
-				"#/components/schemas/MyGlobalResponse",
+				"#/components/schemas/github.com_go-fuego_fuego_MyGlobalResponse",
 				routeCustom.Operation.Responses.Value("202").Value.Content.Get("application/x-yaml").Schema.Ref,
 			)
 		})
@@ -196,7 +196,7 @@ func TestWithGlobalResponseType(t *testing.T) {
 				OptionDefaultResponse("Default response", Response{Type: HTTPError{}}),
 			)
 			assert.Equal(t, "Default response", *route.Operation.Responses.Value("default").Value.Description)
-			assert.Equal(t, "#/components/schemas/HTTPError", route.Operation.Responses.Value("default").Value.Content.Get("application/json").Schema.Ref)
+			assert.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_HTTPError", route.Operation.Responses.Value("default").Value.Content.Get("application/json").Schema.Ref)
 		})
 	})
 

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -605,7 +605,7 @@ func TestValidationTags(t *testing.T) {
 		Name string `json:"name" validate:"required,min=3,max=10" description:"Name of the user" example:"John"`
 		Age  int    `json:"age" validate:"min=18,max=100" description:"Age of the user" example:"25"`
 	}
-	typeOfMyType := reflect.TypeOf(MyType{})
+	typeOfMyType := reflect.TypeFor[MyType]()
 
 	s := NewServer()
 	Get(s, "/data", func(ContextNoBody) (MyType, error) {
@@ -648,7 +648,7 @@ func TestEmbeddedStructHandling(t *testing.T) {
 		InnerStruct
 		FieldB int `json:"field_b" example:"100" description:"B field in the outer struct"`
 	}
-	typeOfOuterStruct := reflect.TypeOf(OuterStruct{})
+	typeOfOuterStruct := reflect.TypeFor[OuterStruct]()
 
 	// Register a route that returns OuterStruct
 	Get(s, "/embedded", func(ContextNoBody) (OuterStruct, error) {
@@ -750,8 +750,8 @@ func TestSetGeneratorSchemaCustomizer(t *testing.T) {
 		Cover Cover  `json:"cover"`
 		Empty Empty  `json:"empty"`
 	}
-	typeOfPage := reflect.TypeOf(Page{})
-	typeOfBook := reflect.TypeOf(Book{})
+	typeOfPage := reflect.TypeFor[Page]()
+	typeOfBook := reflect.TypeFor[Book]()
 
 	s := NewServer(WithEngineOptions(WithOpenAPIGeneratorSchemaCustomizer(customTagParser)))
 	Get(s, "/book", func(ContextNoBody) (Book, error) {
@@ -802,32 +802,32 @@ func TestOpenAPITypeNameGenerator(t *testing.T) {
 	}{
 		{
 			name:     "plain struct type from this package",
-			input:    reflect.TypeOf(MyStruct{}),
+			input:    reflect.TypeFor[MyStruct](),
 			expected: "github.com_go-fuego_fuego_MyStruct",
 		},
 		{
 			name:     "standard library type",
-			input:    reflect.TypeOf(http.Request{}),
+			input:    reflect.TypeFor[http.Request](),
 			expected: "net_http_Request",
 		},
 		{
 			name:     "external package type",
-			input:    reflect.TypeOf(openapi3.Schema{}),
+			input:    reflect.TypeFor[openapi3.Schema](),
 			expected: "github.com_getkin_kin-openapi_openapi3_Schema",
 		},
 		{
 			name:     "primitive type string",
-			input:    reflect.TypeOf(""),
+			input:    reflect.TypeFor[string](),
 			expected: "string",
 		},
 		{
 			name:     "primitive type int",
-			input:    reflect.TypeOf(0),
+			input:    reflect.TypeFor[int](),
 			expected: "int",
 		},
 		{
 			name:     "generic struct type",
-			input:    reflect.TypeOf(DataOrTemplate[MyStruct]{}),
+			input:    reflect.TypeFor[DataOrTemplate[MyStruct]](),
 			expected: "github.com_go-fuego_fuego_DataOrTemplate-github.com_go-fuego_fuego.MyStruct",
 		},
 	}

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -78,7 +78,7 @@ func Test_tagFromType(t *testing.T) {
 			description: "basic struct",
 			inputType:   MyStruct{},
 
-			expectedTagValue:     "MyStruct",
+			expectedTagValue:     "github.com_go-fuego_fuego_MyStruct",
 			expectedTagValueType: &openapi3.Types{"object"},
 		},
 		{
@@ -86,7 +86,7 @@ func Test_tagFromType(t *testing.T) {
 			description: "",
 			inputType:   MyStructWithNested{},
 
-			expectedTagValue:     "MyStructWithNested",
+			expectedTagValue:     "github.com_go-fuego_fuego_MyStructWithNested",
 			expectedTagValueType: &openapi3.Types{"object"},
 		},
 		{
@@ -94,7 +94,7 @@ func Test_tagFromType(t *testing.T) {
 			description: "",
 			inputType:   &MyStruct{},
 
-			expectedTagValue:     "MyStruct",
+			expectedTagValue:     "github.com_go-fuego_fuego_MyStruct",
 			expectedTagValueType: &openapi3.Types{"object"},
 		},
 		{
@@ -102,7 +102,7 @@ func Test_tagFromType(t *testing.T) {
 			description: "",
 			inputType:   []MyStruct{},
 
-			expectedTagValue:     "MyStruct",
+			expectedTagValue:     "github.com_go-fuego_fuego_MyStruct",
 			expectedTagValueType: &openapi3.Types{"array"},
 		},
 		{
@@ -110,7 +110,7 @@ func Test_tagFromType(t *testing.T) {
 			description: "",
 			inputType:   &[]MyStruct{},
 
-			expectedTagValue:     "MyStruct",
+			expectedTagValue:     "github.com_go-fuego_fuego_MyStruct",
 			expectedTagValueType: &openapi3.Types{"array"},
 		},
 		{
@@ -118,7 +118,7 @@ func Test_tagFromType(t *testing.T) {
 			description: "behind 4 pointers",
 			inputType:   new(DeeplyNested),
 
-			expectedTagValue:     "MyStruct",
+			expectedTagValue:     "github.com_go-fuego_fuego_MyStruct",
 			expectedTagValueType: &openapi3.Types{"array"},
 		},
 		{
@@ -126,7 +126,7 @@ func Test_tagFromType(t *testing.T) {
 			description: "behind 5 pointers",
 			inputType:   *new(MoreDeeplyNested),
 
-			expectedTagValue:     "MyStruct",
+			expectedTagValue:     "github.com_go-fuego_fuego_MyStruct",
 			expectedTagValueType: &openapi3.Types{"array"},
 		},
 		{
@@ -181,7 +181,7 @@ func Test_tagFromType(t *testing.T) {
 			description: "",
 			inputType:   DataOrTemplate[MyStruct]{},
 
-			expectedTagValue:     "MyStruct",
+			expectedTagValue:     "github.com_go-fuego_fuego_MyStruct",
 			expectedTagValueType: &openapi3.Types{"object"},
 		},
 		{
@@ -189,7 +189,7 @@ func Test_tagFromType(t *testing.T) {
 			description: "",
 			inputType:   &DataOrTemplate[MyStruct]{},
 
-			expectedTagValue:     "MyStruct",
+			expectedTagValue:     "github.com_go-fuego_fuego_MyStruct",
 			expectedTagValueType: &openapi3.Types{"object"},
 		},
 		{
@@ -197,7 +197,7 @@ func Test_tagFromType(t *testing.T) {
 			description: "",
 			inputType:   DataOrTemplate[[]MyStruct]{},
 
-			expectedTagValue:     "MyStruct",
+			expectedTagValue:     "github.com_go-fuego_fuego_MyStruct",
 			expectedTagValueType: &openapi3.Types{"array"},
 		},
 		{
@@ -205,7 +205,7 @@ func Test_tagFromType(t *testing.T) {
 			description: "",
 			inputType:   &DataOrTemplate[[]*MyStruct]{},
 
-			expectedTagValue:     "MyStruct",
+			expectedTagValue:     "github.com_go-fuego_fuego_MyStruct",
 			expectedTagValueType: &openapi3.Types{"array"},
 		},
 		{
@@ -213,7 +213,7 @@ func Test_tagFromType(t *testing.T) {
 			description: "",
 			inputType:   &DataOrTemplate[*[]MyStruct]{},
 
-			expectedTagValue:     "MyStruct",
+			expectedTagValue:     "github.com_go-fuego_fuego_MyStruct",
 			expectedTagValueType: &openapi3.Types{"array"},
 		},
 		{
@@ -281,9 +281,9 @@ func Test_tagFromType(t *testing.T) {
 		nestedProperty := tag.Value.Properties["nested"]
 		require.NotNil(t, nestedProperty)
 		// Nested struct should be a $ref to a component schema
-		assert.Equal(t, "#/components/schemas/MyStruct", nestedProperty.Ref)
+		assert.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_MyStruct", nestedProperty.Ref)
 		// Look up the nested schema from components
-		nestedSchema, ok := s.OpenAPI.Description().Components.Schemas["MyStruct"]
+		nestedSchema, ok := s.OpenAPI.Description().Components.Schemas["github.com_go-fuego_fuego_MyStruct"]
 		require.True(t, ok)
 		require.NotNil(t, nestedSchema)
 		require.NotNil(t, nestedSchema.Value)
@@ -348,10 +348,10 @@ func TestServer_generateOpenAPI(t *testing.T) {
 	require.Nil(t, document.Paths.Find("/unknown"))
 	require.NotNil(t, document.Paths.Find("/post"))
 	require.Equal(t, &openapi3.Types{"array"}, document.Paths.Find("/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type)
-	require.Equal(t, "#/components/schemas/MyStruct", document.Paths.Find("/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Items.Ref)
+	require.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_MyStruct", document.Paths.Find("/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Items.Ref)
 	require.Equal(t, &openapi3.Types{"array"}, document.Paths.Find("/multidimensional/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type)
 	require.Equal(t, &openapi3.Types{"array"}, document.Paths.Find("/multidimensional/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Items.Value.Type)
-	require.Equal(t, "#/components/schemas/MyStruct", document.Paths.Find("/multidimensional/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Items.Value.Items.Ref)
+	require.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_MyStruct", document.Paths.Find("/multidimensional/post").Post.Responses.Value("200").Value.Content["application/json"].Schema.Value.Items.Value.Items.Ref)
 	require.NotNil(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200"))
 	require.NotNil(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200").Value.Content["application/json"])
 	require.Nil(t, document.Paths.Find("/post/{id}").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value.Properties["unknown"])
@@ -605,6 +605,7 @@ func TestValidationTags(t *testing.T) {
 		Name string `json:"name" validate:"required,min=3,max=10" description:"Name of the user" example:"John"`
 		Age  int    `json:"age" validate:"min=18,max=100" description:"Age of the user" example:"25"`
 	}
+	typeOfMyType := reflect.TypeOf(MyType{})
 
 	s := NewServer()
 	Get(s, "/data", func(ContextNoBody) (MyType, error) {
@@ -616,7 +617,10 @@ func TestValidationTags(t *testing.T) {
 	require.NotNil(t, document.Paths.Find("/data").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value.Properties["name"].Value.Description)
 	require.Equal(t, "Name of the user", document.Paths.Find("/data").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value.Properties["name"].Value.Description)
 
-	myTypeValue := document.Components.Schemas["MyType"].Value
+	myType := document.Components.Schemas[OpenAPITypeNameGenerator(typeOfMyType)]
+	require.NotNil(t, myType)
+	myTypeValue := myType.Value
+	require.NotNil(t, myTypeValue)
 	t.Logf("myType: %+v", myTypeValue)
 	t.Logf("name: %+v", myTypeValue.Properties["name"])
 	t.Logf("age: %+v", myTypeValue.Properties["age"])
@@ -644,6 +648,7 @@ func TestEmbeddedStructHandling(t *testing.T) {
 		InnerStruct
 		FieldB int `json:"field_b" example:"100" description:"B field in the outer struct"`
 	}
+	typeOfOuterStruct := reflect.TypeOf(OuterStruct{})
 
 	// Register a route that returns OuterStruct
 	Get(s, "/embedded", func(ContextNoBody) (OuterStruct, error) {
@@ -655,24 +660,26 @@ func TestEmbeddedStructHandling(t *testing.T) {
 	require.NotNil(t, document)
 
 	// Ensure that both the embedded and non-embedded fields are present in the schema
-	outerSchema := document.Components.Schemas["OuterStruct"].Value
+	outerSchema := document.Components.Schemas[OpenAPITypeNameGenerator(typeOfOuterStruct)]
 	require.NotNil(t, outerSchema)
+	outerSchemaValue := outerSchema.Value
+	require.NotNil(t, outerSchemaValue)
 
 	// Check if embedded struct fields are included
-	require.NotNil(t, outerSchema.Properties["field_a"])
-	assert.Equal(t, &openapi3.Types{"string"}, outerSchema.Properties["field_a"].Value.Type)
-	assert.Equal(t, "Value A", outerSchema.Properties["field_a"].Value.Example)
-	assert.Equal(t, "A field in the inner struct", outerSchema.Properties["field_a"].Value.Description)
+	require.NotNil(t, outerSchemaValue.Properties["field_a"])
+	assert.Equal(t, &openapi3.Types{"string"}, outerSchemaValue.Properties["field_a"].Value.Type)
+	assert.Equal(t, "Value A", outerSchemaValue.Properties["field_a"].Value.Example)
+	assert.Equal(t, "A field in the inner struct", outerSchemaValue.Properties["field_a"].Value.Description)
 
 	// Check if non-embedded struct fields are included
-	require.NotNil(t, outerSchema.Properties["field_b"])
-	assert.Equal(t, &openapi3.Types{"integer"}, outerSchema.Properties["field_b"].Value.Type)
-	assert.Equal(t, 100, outerSchema.Properties["field_b"].Value.Example)
-	assert.Equal(t, "B field in the outer struct", outerSchema.Properties["field_b"].Value.Description)
+	require.NotNil(t, outerSchemaValue.Properties["field_b"])
+	assert.Equal(t, &openapi3.Types{"integer"}, outerSchemaValue.Properties["field_b"].Value.Type)
+	assert.Equal(t, 100, outerSchemaValue.Properties["field_b"].Value.Example)
+	assert.Equal(t, "B field in the outer struct", outerSchemaValue.Properties["field_b"].Value.Description)
 
 	// Both fields should be required (no omitempty tag)
-	assert.Contains(t, outerSchema.Required, "field_a", "embedded struct fields without omitempty should be required")
-	assert.Contains(t, outerSchema.Required, "field_b", "outer struct fields without omitempty should be required")
+	assert.Contains(t, outerSchemaValue.Required, "field_a", "embedded struct fields without omitempty should be required")
+	assert.Contains(t, outerSchemaValue.Required, "field_b", "outer struct fields without omitempty should be required")
 }
 
 func TestDeclareCustom200Response(t *testing.T) {
@@ -743,6 +750,8 @@ func TestSetGeneratorSchemaCustomizer(t *testing.T) {
 		Cover Cover  `json:"cover"`
 		Empty Empty  `json:"empty"`
 	}
+	typeOfPage := reflect.TypeOf(Page{})
+	typeOfBook := reflect.TypeOf(Book{})
 
 	s := NewServer(WithEngineOptions(WithOpenAPIGeneratorSchemaCustomizer(customTagParser)))
 	Get(s, "/book", func(ContextNoBody) (Book, error) {
@@ -752,11 +761,15 @@ func TestSetGeneratorSchemaCustomizer(t *testing.T) {
 	// Get openapi spec
 	openApiSpec := s.OutputOpenAPISpec()
 	require.NotNil(t, openApiSpec)
-	bookValue := openApiSpec.Components.Schemas["Book"].Value
+
+	bookSchema := openApiSpec.Components.Schemas[OpenAPITypeNameGenerator(typeOfBook)]
+	require.NotNil(t, bookSchema)
+	bookValue := bookSchema.Value
+	require.NotNil(t, bookValue)
 
 	// Make sure cover is a reference
 	require.NotEmpty(t, bookValue.Properties["cover"])
-	require.Equal(t, "#/components/schemas/Cover", bookValue.Properties["cover"].Ref)
+	require.Contains(t, bookValue.Properties["cover"].Ref, "Cover")
 
 	require.NotEmpty(t, bookValue.Properties["empty"])
 	require.Empty(t, bookValue.Properties["empty"].Ref)
@@ -767,11 +780,11 @@ func TestSetGeneratorSchemaCustomizer(t *testing.T) {
 	require.Empty(t, pagesValue.Description)
 
 	// Page should be a separate component schema referenced via $ref
-	pageSchemaRef, ok := openApiSpec.Components.Schemas["Page"]
-	require.True(t, ok, "Page should be a separate component schema")
-	require.NotNil(t, pageSchemaRef.Value)
+	pageSchema := openApiSpec.Components.Schemas[OpenAPITypeNameGenerator(typeOfPage)]
+	require.NotNil(t, pageSchema, "Page should be a separate component schema")
+	pageValue := pageSchema.Value
+	require.NotNil(t, pageValue)
 
-	pageValue := pageSchemaRef.Value
 	// Now the num_words should have the custom tag
 	num_wordsValue := pageValue.Properties["num_words"].Value
 	require.NotEmpty(t, num_wordsValue.Description)
@@ -781,73 +794,91 @@ func TestSetGeneratorSchemaCustomizer(t *testing.T) {
 	)
 }
 
-func Test_transformTypeName(t *testing.T) {
+func TestOpenAPITypeNameGenerator(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    string
+		input    reflect.Type
 		expected string
 	}{
 		{
-			name:     "simple generic type",
-			input:    "Response[model.User]",
-			expected: "Response_model.User",
+			name:     "plain struct type from this package",
+			input:    reflect.TypeOf(MyStruct{}),
+			expected: "github.com_go-fuego_fuego_MyStruct",
 		},
 		{
-			name:     "no generic brackets",
-			input:    "PlainType",
-			expected: "PlainType",
+			name:     "standard library type",
+			input:    reflect.TypeOf(http.Request{}),
+			expected: "net_http_Request",
 		},
 		{
-			name:     "generic with package path",
-			input:    "Response[github.com/org/repo/model.User]",
-			expected: "Response_model.User",
+			name:     "external package type",
+			input:    reflect.TypeOf(openapi3.Schema{}),
+			expected: "github.com_getkin_kin-openapi_openapi3_Schema",
 		},
 		{
-			name:     "slice type parameter",
-			input:    "Response[[]model.QuotaData]",
-			expected: "Response_Array-model.QuotaData",
+			name:     "primitive type string",
+			input:    reflect.TypeOf(""),
+			expected: "string",
 		},
 		{
-			name:     "slice type parameter with package path",
-			input:    "Response[[]github.com/org/repo/model.QuotaData]",
-			expected: "Response_Array-model.QuotaData",
+			name:     "primitive type int",
+			input:    reflect.TypeOf(0),
+			expected: "int",
 		},
 		{
-			name:     "pointer type parameter",
-			input:    "Response[*model.User]",
-			expected: "Response_model.User",
-		},
-		{
-			name:     "pointer type parameter with package path",
-			input:    "Response[*github.com/org/repo/model.User]",
-			expected: "Response_model.User",
-		},
-		{
-			name:     "map type parameter",
-			input:    "Response[map[string]model.User]",
-			expected: "Response_map-string-model.User",
-		},
-		{
-			name:     "map type parameter with package path",
-			input:    "Response[map[string]github.com/org/repo/model.User]",
-			expected: "Response_map-string-model.User",
-		},
-		{
-			name:     "nested generic",
-			input:    "Outer[Inner[model.User]]",
-			expected: "Outer_Inner-model.User",
-		},
-		{
-			name:     "nested generic with package path",
-			input:    "Outer[Inner[github.com/org/repo/model.User]]",
-			expected: "Outer_Inner-model.User",
+			name:     "generic struct type",
+			input:    reflect.TypeOf(DataOrTemplate[MyStruct]{}),
+			expected: "github.com_go-fuego_fuego_DataOrTemplate-github.com_go-fuego_fuego.MyStruct",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := transformTypeName(tt.input)
+			result := OpenAPITypeNameGenerator(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestOutputOpenAPISpec_SelfReferentialStruct(t *testing.T) {
+	// This test ensures that self-referential structs (which create cycles in the
+	// schema graph) do not cause infinite recursion during resolveSchemaRefs.
+	type TreeNode struct {
+		Value    string      `json:"value"`
+		Children []*TreeNode `json:"children,omitempty"`
+	}
+
+	s := NewServer()
+	Get(s, "/tree", func(ContextNoBody) (TreeNode, error) {
+		return TreeNode{}, nil
+	})
+
+	// Should not panic or hang due to infinite recursion
+	document := s.OutputOpenAPISpec()
+	require.NotNil(t, document)
+	require.NotNil(t, document.Paths.Find("/tree"))
+}
+
+func TestOutputOpenAPISpec_MutuallyRecursiveStructs(t *testing.T) {
+	// Two structs that reference each other, creating a cycle.
+	type B struct {
+		Name string `json:"name"`
+	}
+	type A struct {
+		Related *B `json:"related,omitempty"`
+	}
+
+	s := NewServer()
+	Get(s, "/a", func(ContextNoBody) (A, error) {
+		return A{}, nil
+	})
+	Get(s, "/b", func(ContextNoBody) (B, error) {
+		return B{}, nil
+	})
+
+	// Should not panic or hang
+	document := s.OutputOpenAPISpec()
+	require.NotNil(t, document)
+	require.NotNil(t, document.Paths.Find("/a"))
+	require.NotNil(t, document.Paths.Find("/b"))
 }

--- a/option_test.go
+++ b/option_test.go
@@ -375,7 +375,7 @@ func TestRequestContentType(t *testing.T) {
 		content := route.Operation.RequestBody.Value.Content
 		require.NotNil(t, content.Get("application/json"))
 		require.Nil(t, content.Get("application/xml"))
-		require.Equal(t, "#/components/schemas/ReqBody", content.Get("application/json").Schema.Ref)
+		require.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_test_ReqBody", content.Get("application/json").Schema.Ref)
 		_, ok := s.OpenAPI.Description().Components.RequestBodies["ReqBody"]
 		require.False(t, ok)
 	})
@@ -390,8 +390,8 @@ func TestRequestContentType(t *testing.T) {
 		require.NotNil(t, content.Get("application/json"))
 		require.NotNil(t, content.Get("my/content-type"))
 		require.Nil(t, content.Get("application/xml"))
-		require.Equal(t, "#/components/schemas/ReqBody", content.Get("application/json").Schema.Ref)
-		require.Equal(t, "#/components/schemas/ReqBody", content.Get("my/content-type").Schema.Ref)
+		require.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_test_ReqBody", content.Get("application/json").Schema.Ref)
+		require.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_test_ReqBody", content.Get("my/content-type").Schema.Ref)
 		_, ok := s.OpenAPI.Description().Components.RequestBodies["ReqBody"]
 		require.False(t, ok)
 	})
@@ -409,7 +409,7 @@ func TestRequestContentType(t *testing.T) {
 		require.Nil(t, content.Get("application/json"))
 		require.Nil(t, content.Get("application/xml"))
 		require.NotNil(t, content.Get("my/content-type"))
-		require.Equal(t, "#/components/schemas/ReqBody", content.Get("my/content-type").Schema.Ref)
+		require.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_test_ReqBody", content.Get("my/content-type").Schema.Ref)
 		_, ok := s.OpenAPI.Description().Components.RequestBodies["ReqBody"]
 		require.False(t, ok)
 	})
@@ -489,7 +489,7 @@ func TestAddResponse(t *testing.T) {
 		require.Nil(t, resp.Value.Content.Get("application/json"))
 		require.Nil(t, resp.Value.Content.Get("application/xml"))
 		require.NotNil(t, resp.Value.Content.Get("application/x-yaml"))
-		require.Equal(t, "#/components/schemas/HTTPError", resp.Value.Content.Get("application/x-yaml").Schema.Ref)
+		require.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_HTTPError", resp.Value.Content.Get("application/x-yaml").Schema.Ref)
 		require.Equal(t, "set 200", *route.Operation.Responses.Value("200").Value.Description)
 	})
 
@@ -523,8 +523,8 @@ func TestRequestBody(t *testing.T) {
 		require.NotNil(t, req)
 		assert.NotContains(t, req.Value.Content, "application/xml")
 		require.Contains(t, req.Value.Content, "application/json")
-		assert.Equal(t, "#/components/schemas/TestModel", req.Value.Content.Get("application/json").Schema.Ref)
-		assert.NotNil(t, s.OpenAPI.Description().Components.Schemas["TestModel"])
+		assert.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_test_TestModel", req.Value.Content.Get("application/json").Schema.Ref)
+		assert.NotNil(t, s.OpenAPI.Description().Components.Schemas["github.com_go-fuego_fuego_test_TestModel"])
 	})
 
 	t.Run("no content types provided", func(t *testing.T) {
@@ -538,8 +538,8 @@ func TestRequestBody(t *testing.T) {
 		require.NotNil(t, req)
 		require.Contains(t, req.Value.Content, "application/json")
 		assert.Contains(t, req.Value.Content, "application/xml")
-		assert.Equal(t, "#/components/schemas/TestModel", req.Value.Content.Get("application/json").Schema.Ref)
-		assert.Contains(t, s.OpenAPI.Description().Components.Schemas, "TestModel")
+		assert.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_test_TestModel", req.Value.Content.Get("application/json").Schema.Ref)
+		assert.Contains(t, s.OpenAPI.Description().Components.Schemas, "github.com_go-fuego_fuego_test_TestModel")
 	})
 
 	t.Run("multiple inputs", func(t *testing.T) {
@@ -560,9 +560,9 @@ func TestRequestBody(t *testing.T) {
 		require.Len(t, req.Value.Content, 2)
 		assert.NotContains(t, req.Value.Content, "application/xml")
 		require.Contains(t, req.Value.Content, "application/json")
-		assert.Equal(t, "#/components/schemas/TestModel", req.Value.Content.Get("application/json").Schema.Ref)
+		assert.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_test_TestModel", req.Value.Content.Get("application/json").Schema.Ref)
 		require.Contains(t, req.Value.Content, "custom-type")
-		assert.Equal(t, "#/components/schemas/AnotherTestModel", req.Value.Content.Get("custom-type").Schema.Ref)
+		assert.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_test_AnotherTestModel", req.Value.Content.Get("custom-type").Schema.Ref)
 	})
 
 	t.Run("override previous input", func(t *testing.T) {
@@ -582,8 +582,8 @@ func TestRequestBody(t *testing.T) {
 		require.NotNil(t, req)
 		require.Len(t, req.Value.Content, 1)
 		require.Contains(t, req.Value.Content, "application/json")
-		assert.NotEqual(t, "#/components/schemas/TestModel", req.Value.Content.Get("application/json").Schema.Ref)
-		assert.Equal(t, "#/components/schemas/AnotherTestModel", req.Value.Content.Get("application/json").Schema.Ref)
+		assert.NotEqual(t, "#/components/schemas/github.com_go-fuego_fuego_test_TestModel", req.Value.Content.Get("application/json").Schema.Ref)
+		assert.Equal(t, "#/components/schemas/github.com_go-fuego_fuego_test_AnotherTestModel", req.Value.Content.Get("application/json").Schema.Ref)
 	})
 
 	t.Run("should be fatal", func(t *testing.T) {

--- a/schema_customizer.go
+++ b/schema_customizer.go
@@ -97,8 +97,8 @@ func determineFieldConstraints(t reflect.Type, schema *openapi3.Schema) {
 	if t.Kind() != reflect.Struct {
 		return
 	}
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
+	for f := range t.Fields() {
+		f := f
 
 		// Recurse into embedded struct fields
 		if f.Anonymous {

--- a/serialization.go
+++ b/serialization.go
@@ -37,7 +37,7 @@ type OutTransformer interface {
 }
 
 func transformOut[T any](ctx context.Context, ans T) (T, error) {
-	if reflect.TypeOf(ans).Kind() == reflect.Ptr {
+	if reflect.TypeOf(ans).Kind() == reflect.Pointer {
 		// If ans is a nil pointer, we do not want to transform it.
 		if reflect.ValueOf(ans).IsNil() {
 			return ans, nil

--- a/serve.go
+++ b/serve.go
@@ -217,7 +217,7 @@ func isNilError(err error) bool {
 		return true
 	}
 	v := reflect.ValueOf(err)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		return v.IsNil()
 	}
 	return false


### PR DESCRIPTION
I had ran into an edge case where there are two (or more) structs with the same name but under different packages. 
The openapi generation would success but the output for the second struct is completely wrong. 
From investigation, it had lead me to conclude that the structs with same name would overlap each other as result of transformTypeName() outputting the same string. 

My thought here is to change the schema name to include the package to guarantee global uniqueness. One of the possible downside here would potentially be the schema name is now less human readable... Please have a review on this and let me know your thoughts. 

Thanks,